### PR TITLE
fix(server): reload minio filesystem for each server query

### DIFF
--- a/deploy/modos-server/server.py
+++ b/deploy/modos-server/server.py
@@ -21,17 +21,13 @@ BUCKET = os.environ["S3_BUCKET"]
 HTSGET_LOCAL_URL = os.environ["HTSGET_LOCAL_URL"]
 
 app = FastAPI()
-
-
-def connect_s3():
-    return s3fs.S3FileSystem(anon=True, endpoint_url=S3_LOCAL_URL)
+minio = s3fs.S3FileSystem(anon=True, endpoint_url=S3_LOCAL_URL)
 
 
 @app.get("/list")
 def list_modos() -> list[str]:
     """List MODO entries in bucket."""
-    minio = connect_s3()
-    modos = minio.ls(BUCKET)
+    modos = minio.ls(BUCKET, refresh=True)
     # NOTE: modo contains bucket name
     return [modo for modo in modos]
 
@@ -41,8 +37,7 @@ def gather_metadata():
     """Generate metadata KG from all MODOs."""
     meta = {}
 
-    minio = connect_s3()
-    for modo in minio.ls(BUCKET):
+    for modo in minio.ls(BUCKET, refresh=True):
         meta.update(MODO(path=modo, s3_endpoint=S3_LOCAL_URL).metadata)
 
     return meta
@@ -56,8 +51,7 @@ def str_similarity(s1: str, s2: str) -> float:
 @app.get("/get")
 def get_s3_path(query: str, exact_match: bool = False):
     """Receive the S3 path of all modos matching the query"""
-    minio = connect_s3()
-    modos = minio.ls(BUCKET)
+    modos = minio.ls(BUCKET, refresh=True)
     paths = [modo.removeprefix(BUCKET) for modo in modos]
 
     if exact_match:

--- a/deploy/modos-server/server.py
+++ b/deploy/modos-server/server.py
@@ -21,12 +21,16 @@ BUCKET = os.environ["S3_BUCKET"]
 HTSGET_LOCAL_URL = os.environ["HTSGET_LOCAL_URL"]
 
 app = FastAPI()
-minio = s3fs.S3FileSystem(anon=True, endpoint_url=S3_LOCAL_URL)
+
+
+def connect_s3():
+    return s3fs.S3FileSystem(anon=True, endpoint_url=S3_LOCAL_URL)
 
 
 @app.get("/list")
 def list_modos() -> list[str]:
     """List MODO entries in bucket."""
+    minio = connect_s3()
     modos = minio.ls(BUCKET)
     # NOTE: modo contains bucket name
     return [modo for modo in modos]
@@ -37,6 +41,7 @@ def gather_metadata():
     """Generate metadata KG from all MODOs."""
     meta = {}
 
+    minio = connect_s3()
     for modo in minio.ls(BUCKET):
         meta.update(MODO(path=modo, s3_endpoint=S3_LOCAL_URL).metadata)
 
@@ -51,6 +56,7 @@ def str_similarity(s1: str, s2: str) -> float:
 @app.get("/get")
 def get_s3_path(query: str, exact_match: bool = False):
     """Receive the S3 path of all modos matching the query"""
+    minio = connect_s3()
     modos = minio.ls(BUCKET)
     paths = [modo.removeprefix(BUCKET) for modo in modos]
 


### PR DESCRIPTION
The modo server did not register MODOs created after startup. This was due to the s3Fs object caching the filesystem state on instantiation by default.

This adds the `refresh=True` option to always refresh the filesystem when the server receives http requests.

Fixes #59 