### PR TITLE
fix: auto upload cram index

### DIFF
--- a/modos/api.py
+++ b/modos/api.py
@@ -24,7 +24,7 @@ from .helpers import (
     ElementType,
     set_haspart_relationship,
     UserElementType,
-    get_fileformat,
+    GenomicFileFormat,
 )
 from .cram import slice_genomics, slice_remote_genomics
 
@@ -400,9 +400,10 @@ class MODO:
             raise ValueError(f"{file_path} not found in {self.path}.")
 
         if self.s3_endpoint:
-            if get_fileformat(file_path) == "CRAM":
+            fileformat = GenomicFileFormat.from_filepath(Path(file_path)).name
+            if fileformat == "CRAM":
                 endpoint_type = "/reads/"
-            elif get_fileformat(file_path) in ("VCF", "BCF"):
+            elif fileformat in ["VCF", "BCF"]:
                 endpoint_type = "/variants/"
 
             # http://domain/s3 + bucket/modo/file.cram --> http://domain/htsget/reads/modo/file.cram

--- a/modos/cram.py
+++ b/modos/cram.py
@@ -16,7 +16,7 @@ import re
 import htsget
 from .helpers import (
     parse_region,
-    get_fileformat,
+    GenomicFileFormat,
     file_to_pysam_object,
     bytesio_to_iterator,
     iter_to_file,
@@ -35,7 +35,7 @@ def slice_genomics(
 
     reference_name, start, end = parse_region(region)
 
-    fileformat = get_fileformat(path)
+    fileformat = GenomicFileFormat.from_filepath(Path(path)).name
 
     infile = file_to_pysam_object(
         path=path, fileformat=fileformat, reference_filename=reference_filename
@@ -63,7 +63,7 @@ def slice_remote_genomics(
     """Stream or write to a local file a slice of a remote CRAM or VCF/BCF file"""
 
     url = urlparse(url)
-    in_fileformat = get_fileformat(url.path)
+    in_fileformat = GenomicFileFormat.from_filepath(Path(url.path)).name
     if in_fileformat not in ("CRAM", "VCF", "BCF") or url.path.endswith(
         ".vcf"
     ):
@@ -93,7 +93,9 @@ def slice_remote_genomics(
 
     # To save remote slice to a local file without converting data type
     if output_filename:
-        out_fileformat = get_fileformat(output_filename)
+        out_fileformat = GenomicFileFormat.from_filepath(
+            Path(output_filename)
+        ).name
         if out_fileformat == in_fileformat:
             with open(output_filename, "wb") as output:
                 for chunk in htsget_response_buffer:

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -280,18 +280,17 @@ class GenomicFileFormat(tuple, Enum):
 
     def get_index_suffix(self):
         """Return the supported index suffix related to a genomic filetype"""
-        if self == GenomicFileFormat.BAM or self == GenomicFileFormat.SAM:
-            return ".bai"
-        elif self == GenomicFileFormat.BCF:
-            return ".csi"
-        elif self == GenomicFileFormat.CRAM:
-            return ".crai"
-        elif (
-            self == GenomicFileFormat.FASTA or self == GenomicFileFormat.FASTQ
-        ):
-            return ".fai"
-        elif self == GenomicFileFormat.VCF:
-            return ".tbi"
+        match self.name:
+            case "BAM" | "SAM":
+                return ".bai"
+            case "BCF":
+                return ".csi"
+            case "CRAM":
+                return ".crai"
+            case "FASTA" | "FASTQ":
+                return ".fai"
+            case "VCF":
+                return ".tbi"
 
 
 def file_to_pysam_object(

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -47,14 +47,18 @@ def copy_file_to_archive(
         # Check for index file
         fi_format = GenomicFileFormat.from_filepath(data_path)
         ix_suffix = GenomicFileFormat.get_index_suffix(fi_format)
-        ix_file = data_path.parent / (data_path.name + ix_suffix)
-        if not ix_file.is_file():
+        ix_path = data_path.parent / (data_path.name + ix_suffix)
+        if not ix_path.is_file():
             raise FileNotFoundError(f"Missing index for {data_path}")
 
         if remote_store:
-            remote_store.put(data_path, base_path / Path(archive_path).parent)
+            for fi in [data_path, ix_path]:
+                remote_store.put_file(
+                    fi, base_path / Path(archive_path).parent
+                )
         else:
-            shutil.copy(data_path, base_path / archive_path)
+            for fi in [data_path, ix_path]:
+                shutil.copy(fi, base_path / archive_path)
 
 
 def set_haspart_relationship(

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -256,7 +256,7 @@ def parse_region(
     return (reference_name, start, end)
 
 
-class GenomicFileFormat(str, Enum):
+class GenomicFileFormat(tuple, Enum):
     """Enumeration of all supported genomic file types."""
 
     CRAM = (".cram",)

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -52,13 +52,11 @@ def copy_file_to_archive(
             raise FileNotFoundError(f"Missing index for {data_path}")
 
         if remote_store:
-            for fi in [data_path, ix_path]:
-                remote_store.put_file(
-                    fi, base_path / Path(archive_path).parent
-                )
+            remote_store.put(data_path, base_path / Path(archive_path).parent)
+            remote_store.put(ix_path, base_path / Path(archive_path).parent)
         else:
-            for fi in [data_path, ix_path]:
-                shutil.copy(fi, base_path / archive_path)
+            shutil.copy(data_path, base_path / archive_path)
+            shutil.copy(ix_path, base_path / (archive_path + ix_suffix))
 
 
 def set_haspart_relationship(
@@ -277,19 +275,22 @@ class GenomicFileFormat(str, Enum):
         if not fi_format:
             supported = [fi_format for fi_format in cls]
             raise ValueError(
-                f'Unsupported file format {"".join(path.suffixes)}. Supported file formats: {supported}'
+                f'Unsupported file format: {"".join(path.suffixes)}.\n'
+                f"Supported formats: {supported}"
             )
         return fi_format
 
     def get_index_suffix(self):
         """Return the supported index suffix related to a genomic filetype"""
-        if self == GenomicFileFormat.BAM | self == GenomicFileFormat.SAM:
+        if self == GenomicFileFormat.BAM or self == GenomicFileFormat.SAM:
             return ".bai"
         elif self == GenomicFileFormat.BCF:
             return ".csi"
         elif self == GenomicFileFormat.CRAM:
             return ".crai"
-        elif self == GenomicFileFormat.FASTA | self == GenomicFileFormat.FASTQ:
+        elif (
+            self == GenomicFileFormat.FASTA or self == GenomicFileFormat.FASTQ
+        ):
             return ".fai"
         elif self == GenomicFileFormat.VCF:
             return ".tbi"

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -259,13 +259,13 @@ def parse_region(
 class GenomicFileFormat(str, Enum):
     """Enumeration of all supported genomic file types."""
 
-    CRAM = [".cram"]
-    FASTA = [".fasta", ".fa"]
-    FASTQ = [".fastq", ".fq"]
-    BAM = [".bam"]
-    SAM = [".sam"]
-    VCF = [".vcf", ".vcf.gz"]
-    BCF = [".bcf"]
+    CRAM = (".cram",)
+    FASTA = (".fasta", ".fa")
+    FASTQ = (".fastq", ".fq")
+    BAM = (".bam",)
+    SAM = (".sam",)
+    VCF = (".vcf", ".vcf.gz")
+    BCF = (".bcf",)
 
     @classmethod
     def from_filepath(cls, path: Path):

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -46,7 +46,7 @@ def copy_file_to_archive(
 
         # Check for index file
         fi_format = GenomicFileFormat.from_filepath(data_path)
-        ix_suffix = GenomicFileFormat.get_index_suffix(fi_format)
+        ix_suffix = fi_format.get_index_suffix()
         ix_path = data_path.parent / (data_path.name + ix_suffix)
         if not ix_path.is_file():
             raise FileNotFoundError(f"Missing index for {data_path}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,10 +40,6 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture
 def test_modo(tmp_path):
     modo = build_modo_from_file(Path("data", "ex_config.yaml"), tmp_path)
-    # TODO: This should be automatically copied. Remove when issue is solved!
-    shutil.copyfile(
-        Path("data", "ex", "demo1.cram.crai"), tmp_path / "demo1.cram.crai"
-    )
     return modo
 
 

--- a/tests/test_api_local.py
+++ b/tests/test_api_local.py
@@ -36,6 +36,7 @@ def test_add_data(data_entity, tmp_path):
     modo = MODO(tmp_path)
     modo.add_element(data_entity, data_file="data/ex/demo1.cram")
     assert "demo1.cram" in [fi.name for fi in modo.list_files()]
+    assert "demo1.cram.crai" in [fi.name for fi in modo.list_files()]
 
 
 def test_add_to_parent(sample, test_modo):

--- a/tests/test_api_remote.py
+++ b/tests/test_api_remote.py
@@ -35,6 +35,7 @@ def test_add_element(assay, remote_modo):
 def test_add_data(data_entity, remote_modo):
     remote_modo.add_element(data_entity, data_file="data/ex/demo1.cram")
     assert "demo1.cram" in [fi.name for fi in remote_modo.list_files()]
+    assert "demo1.cram.crai" in [fi.name for fi in remote_modo.list_files()]
 
 
 ## Remove element

--- a/tests/test_cli_local.py
+++ b/tests/test_cli_local.py
@@ -61,6 +61,7 @@ def test_add_data(tmp_path, data_entity):
     )
     assert result.exit_code == 0
     assert "demo1.cram" in [fi.name for fi in modo.list_files()]
+    assert "demo1.cram.crai" in [fi.name for fi in modo.list_files()]
 
 
 def test_add_to_parent(tmp_path, test_modo, sample):


### PR DESCRIPTION
# Automatically include index file

### Aim: 
Automatically copy the corresponding index file together with any file that is copied into the modo

### Includes:
- Genomic file formats are structured in an Enumeration `GenomicsFileFormat`
- Corresponding index file suffixes can be derived from a `GenomicsFileFormat`
- Index files (same name as the genomics file +  index suffix) are automatically copied into modo.
- `FileNotFoundError` for missing index
- `modos.helpers.get_fileformat()` was replaced to be consistent

### Does not exclude:
- Further refactoring of cram streaming 