### PR TITLE
docs: Format markdown documents

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+printWidth: 80
+tabWidth: 2
+semi: false
+singleQuote: false
+overrides: [{ files: "*.md", options: { proseWrap: always } }]

--- a/README.md
+++ b/README.md
@@ -6,18 +6,23 @@ API for managing and serving Multi-Omics Digital Object System (MODOS).
 
 ### Motivation
 
-Provide a digital object and system to process, store and serve multi-omics data with their metadata such that:
-* Traceability and reproducibility is ensured by rich metadata
-* The different omics layers are processed and distributed together
-* Common operations such as liftover can be automated easily and ensure that omics layers are kept in sync
+Provide a digital object and system to process, store and serve multi-omics data
+with their metadata such that:
+
+- Traceability and reproducibility is ensured by rich metadata
+- The different omics layers are processed and distributed together
+- Common operations such as liftover can be automated easily and ensure that
+  omics layers are kept in sync
 
 ### Architecture
 
 The digital object is composed of a folder with:
-* Genomic data files (CRAM, FASTA)
-* A zarr archive for metadata and array-based database
 
-The metadata links the different files using the [modos-schema](https://sdsc-ordes.github.io/modos-schema).
+- Genomic data files (CRAM, FASTA)
+- A zarr archive for metadata and array-based database
+
+The metadata links the different files using the
+[modos-schema](https://sdsc-ordes.github.io/modos-schema).
 
 ## Installation
 
@@ -29,7 +34,8 @@ pip install git+https://github.com/sdsc-ordes/modos-api.git@main
 
 ## Usage
 
-The user facing API is in `modos.api`. It allows to interact with existing digital objects:
+The user facing API is in `modos.api`. It allows to interact with existing
+digital objects:
 
 ```py
 from modos.api import MODO
@@ -38,7 +44,6 @@ ex = MODO('./example-digital-object')
 ex.list_files()
 ex.list_samples()
 ```
-
 
 ## Development
 
@@ -49,29 +54,56 @@ git clone https://github.com/sdsc-ordes/modos-api && cd modos-api
 make install
 ```
 
-This will install dependencies and create the python virtual environment using [poetry](https://python-poetry.org/) and setup pre-commit hooks with [pre-commit](https://pre-commit.com/).
+This will install dependencies and create the python virtual environment using
+[poetry](https://python-poetry.org/) and setup pre-commit hooks with
+[pre-commit](https://pre-commit.com/).
 
-The tests can be run with `make test`, it will execute pytest with the doctest module.
+The tests can be run with `make test`, it will execute pytest with the doctest
+module.
 
 ## Implementation details
 
-* To allow faster horizontal traversal of digital objects in the catalogue (e.g. for listing), the metadata should be exported in a central database/knowledge-graph on the server side.
-* Metadata can be either embedded in the array file, or stored in a separate file
-* Each digital object needs a unique identifier
-* The paths of individual files in the digital object must be referenced in a consistent way.
-  + Absolute paths are a no-go (machine/system dependent)
-  + Relative paths in the digital object could work, but need to be OS-independent
-
+- To allow faster horizontal traversal of digital objects in the catalogue (e.g.
+  for listing), the metadata should be exported in a central
+  database/knowledge-graph on the server side.
+- Metadata can be either embedded in the array file, or stored in a separate
+  file
+- Each digital object needs a unique identifier
+- The paths of individual files in the digital object must be referenced in a
+  consistent way.
+  - Absolute paths are a no-go (machine/system dependent)
+  - Relative paths in the digital object could work, but need to be
+    OS-independent
 
 ## Status and limitations
 
-* Focusing on data retrieval, remote object creation not yet implemented
-* The htsget protocol supports streaming CRAM files, but it is currently only implemented for BAM in major genome browsers (igv.js, jbrowse)
+- Focusing on data retrieval, remote object creation not yet implemented
+- The htsget protocol supports streaming CRAM files, but it is currently only
+  implemented for BAM in major genome browsers (igv.js, jbrowse)
 
 ## Acknowledgements and Funding
 
-The development of the Multi-Omics Digital Object System (MODOS) is being funded by the Personalized Health Data Analysis Hub, a joint initiative of the Personalized Health and Related Technologies ([PHRT](https://www.sfa-phrt.ch)) and the Swiss Data Science Center ([SDSC](https://datascience.ch)), for a period of three years from 2023 to 2025. The SDSC leads the development of MODOS, bringing expertise in complex data structures associated with multi-omics and imaging data to advance privacy-centric clinical-grade integration. The PHRT contributes its domain expertise of the Swiss Multi-Omics Center ([SMOC](http://smoc.ethz.ch)) in the generation, analysis, and interpretation of multi-omics data for personalized health and precision medicine applications.
-We gratefully acknowledge the [Health 2030 Genome Center](https://www.health2030genome.ch/) for their substantial contributions to the development of MODOS by providing test data sets, deployment infrastructure, and expertise. 
+The development of the Multi-Omics Digital Object System (MODOS) is being funded
+by the Personalized Health Data Analysis Hub, a joint initiative of the
+Personalized Health and Related Technologies ([PHRT](https://www.sfa-phrt.ch))
+and the Swiss Data Science Center ([SDSC](https://datascience.ch)), for a period
+of three years from 2023 to 2025. The SDSC leads the development of MODOS,
+bringing expertise in complex data structures associated with multi-omics and
+imaging data to advance privacy-centric clinical-grade integration. The PHRT
+contributes its domain expertise of the Swiss Multi-Omics Center
+([SMOC](http://smoc.ethz.ch)) in the generation, analysis, and interpretation of
+multi-omics data for personalized health and precision medicine applications. We
+gratefully acknowledge the
+[Health 2030 Genome Center](https://www.health2030genome.ch/) for their
+substantial contributions to the development of MODOS by providing test data
+sets, deployment infrastructure, and expertise.
 
 ## Copyright
-Copyright © 2023-2024 Swiss Data Science Center (SDSC), [www.datascience.ch](http://www.datascience.ch/). All rights reserved. The SDSC is jointly established and legally represented by the École Polytechnique Fédérale de Lausanne (EPFL) and the Eidgenössische Technische Hochschule Zürich (ETH Zürich). This copyright encompasses all materials, software, documentation, and other content created and developed by the SDSC in the context of the Personalized Health Data Analysis Hub.
+
+Copyright © 2023-2024 Swiss Data Science Center (SDSC),
+[www.datascience.ch](http://www.datascience.ch/). All rights reserved. The SDSC
+is jointly established and legally represented by the École Polytechnique
+Fédérale de Lausanne (EPFL) and the Eidgenössische Technische Hochschule Zürich
+(ETH Zürich). This copyright encompasses all materials, software, documentation,
+and other content created and developed by the SDSC in the context of the
+Personalized Health Data Analysis Hub.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,24 +1,27 @@
 # Server deployment
 
-> [!WARNING]
-> This is a work in progress and not production-ready yet.
+> [!WARNING] This is a work in progress and not production-ready yet.
 
 ## Context
 
-This directory contains the necessary files to deploy a multi-omics digital objects (MODOs) server.
+This directory contains the necessary files to deploy a multi-omics digital
+objects (MODOs) server.
 
-The modos-server is meant to provide remote access to the MODOs. Currently, it can:
+The modos-server is meant to provide remote access to the MODOs. Currently, it
+can:
 
-* [x] list available MODO
-* [x] return their metadata
-* [x] expose a MODO directly as a client-accessible S3 bucket / folder
-* [ ] stream CRAM slices CRAM using htsget
-* [ ] manage authentication and access control
+- [x] list available MODO
+- [x] return their metadata
+- [x] expose a MODO directly as a client-accessible S3 bucket / folder
+- [ ] stream CRAM slices CRAM using htsget
+- [ ] manage authentication and access control
 
-The MODOs are stored in an s3 (minio) bucket, and an htsget server is deployed alongside the modos-server to handle slicing and streaming of CRAM files. A REST API is exposed to the client to interact with the remote MODOs.
+The MODOs are stored in an s3 (minio) bucket, and an htsget server is deployed
+alongside the modos-server to handle slicing and streaming of CRAM files. A REST
+API is exposed to the client to interact with the remote MODOs.
 
-All services are accessible at a single access point through an nginx reverse proxy on port 80.
-
+All services are accessible at a single access point through an nginx reverse
+proxy on port 80.
 
 ```mermaid
 flowchart TB
@@ -45,31 +48,34 @@ end
 
 ## Setup
 
-> [!IMPORTANT]
-> The instructions below are meant for local testing.
-> Production use would require changing the default
-> credentials and use authentication.
+> [!IMPORTANT] The instructions below are meant for local testing. Production
+> use would require changing the default credentials and use authentication.
 
 1. Start the server
+
 ```sh
 cd deploy
 docker compose up --build
 ```
-2. Upload MODO(s) to the default bucket from the minio console (default is http://localhost:9001)
+
+2. Upload MODO(s) to the default bucket from the minio console (default is
+   http://localhost:9001)
 3. Login to the minio console (default credentials are minio/miniosecret)
 
 ## Usage
 
 Once the server is started, a client can connect to the following endpoints:
-* `http://localhost:80/htsget`: directly access the htsget server
-* `http://localhost:80/s3`: directly access the s3 server
-* `http://localhost:80/list`: list modos on the server
-* `http://localhost:80/meta`: return all metadata on the server
+
+- `http://localhost:80/htsget`: directly access the htsget server
+- `http://localhost:80/s3`: directly access the s3 server
+- `http://localhost:80/list`: list modos on the server
+- `http://localhost:80/meta`: return all metadata on the server
 
 ## Configuration
 
-Most parameters can be configured using environment variables.
-The easiest way to change environment variables is to use a `.env`. An example is provided and can be used as follows:
+Most parameters can be configured using environment variables. The easiest way
+to change environment variables is to use a `.env`. An example is provided and
+can be used as follows:
 
 ```sh
 mv .example.env .env

--- a/docs/changelog-link.md
+++ b/docs/changelog-link.md
@@ -1,2 +1,3 @@
 ```{include} ../CHANGELOG.md
+
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,115 +1,79 @@
-
-:::{image} img/modos.png
-   :width: 200
-   :alt: modos logo
-:::
-
+:::{image} img/modos.png :width: 200 :alt: modos logo :::
 
 # Welcome to modos-api's documentation!
 
-modos-api (__Multi-Omics Digital Object System__) is a python library and command line tool to process, store and serve multi-omics data together with their metadata.
-It allows remote storage and access using <a href="https://github.com/zarr-developers/zarr-python" target="_blank">zarr</a>'s S3 compatibility and integrates <a href="https://github.com/ga4gh/htsget" target="_blank">htsget</a> to stream and access genomics data.
+modos-api (**Multi-Omics Digital Object System**) is a python library and
+command line tool to process, store and serve multi-omics data together with
+their metadata. It allows remote storage and access using
+<a href="https://github.com/zarr-developers/zarr-python" target="_blank">zarr</a>'s
+S3 compatibility and integrates
+<a href="https://github.com/ga4gh/htsget" target="_blank">htsget</a> to stream
+and access genomics data.
 
 ::::{grid} 3
 
-:::{grid-item-card} {octicon}`rocket;2em`  Quick start
-A user guide to get started and try modos-api
+:::{grid-item-card} {octicon}`rocket;2em` Quick start A user guide to get
+started and try modos-api
 
-:::{button-ref} intro/quickstart
-:ref-type: myst
-:expand:
-:color: dark
+:::{button-ref} intro/quickstart :ref-type: myst :expand: :color: dark
 :click-parent:
 
-Try it out!
-:::
+Try it out! :::
 
 :::
 
+:::{grid-item-card} {octicon}`project;2em` Tutorials A list of tutorials and
+how-to user guides.
 
-:::{grid-item-card} {octicon}`project;2em` Tutorials
-A list of tutorials and how-to user guides.
-
-:::{button-ref} tutorials/tutorials
-:ref-type: myst
-:expand:
-:color: dark
+:::{button-ref} tutorials/tutorials :ref-type: myst :expand: :color: dark
 :click-parent:
 
-Guided tutorials!
-:::
+Guided tutorials! :::
 
 :::
 
-:::{grid-item-card} {octicon}`report;2em` API reference
-A reference guide to all python api classes and functions.
+:::{grid-item-card} {octicon}`report;2em` API reference A reference guide to all
+python api classes and functions.
 
-:::{button-ref} autoapi/index
-:ref-type: myst
-:expand:
-:color: dark
+:::{button-ref} autoapi/index :ref-type: myst :expand: :color: dark
 :click-parent:
 
-To the python API!
-:::
+To the python API! :::
 
 :::
 
-:::{grid-item-card} {octicon}`code-square;2em` CLI reference
-A reference guide to all cli functions, their parameters and options.
+:::{grid-item-card} {octicon}`code-square;2em` CLI reference A reference guide
+to all cli functions, their parameters and options.
 
-:::{button-ref} cli
-:ref-type: myst
-:expand:
-:color: dark
+:::{button-ref} cli :ref-type: myst :expand: :color: dark :click-parent:
+
+Check the CLI! :::
+
+:::
+
+:::{grid-item-card} {octicon}`book;2em` Background Read more about
+**multiomics** data and MODOS's features and structure!
+
+:::{button-ref} intro/background :ref-type: myst :expand: :color: dark
 :click-parent:
 
-Check the CLI!
-:::
+Learn more about MODOS! :::
 
 :::
 
-:::{grid-item-card} {octicon}`book;2em` Background
-Read more about __multiomics__ data and MODOS's features and structure!
+:::{grid-item-card} {octicon}`beaker;2em` Modos-schema Check our data model for
+advanced and custom usage of modos-api.
 
-:::{button-ref} intro/background
-:ref-type: myst
-:expand:
-:color: dark
-:click-parent:
+:::{button-link} https://sdsc-ordes.github.io/modos-schema/ :ref-type: myst
+:expand: :color: dark :click-parent:
 
-Learn more about MODOS!
-:::
-
-:::
-
-:::{grid-item-card} {octicon}`beaker;2em` Modos-schema
-Check our data model for advanced and custom usage of modos-api.
-
-:::{button-link} https://sdsc-ordes.github.io/modos-schema/
-:ref-type: myst
-:expand:
-:color: dark
-:click-parent:
-
-To the data model!
-:::
+To the data model! :::
 
 :::
 
 ::::
 
+:::{toctree} :maxdepth: 1 :hidden:
 
-
-
-:::{toctree}
-:maxdepth: 1
-:hidden:
-
-intro/quickstart.md
-intro/background.md
-tutorials/tutorials.md
-autoapi/index
-cli.rst
-changelog-link
-:::
+intro/quickstart.md intro/background.md tutorials/tutorials.md autoapi/index
+cli.rst changelog-link :::

--- a/docs/intro/background.md
+++ b/docs/intro/background.md
@@ -2,21 +2,28 @@
 
 ## Multiomics - the (full) picture
 
-Molecular mechanisms are highly regulated at various levels. Different omic layers (genomics, transcriptomics, proteomics, metabolomics) interact and communicate with each other to establish specific phenotypes. Thus, it can be crucial to explore several of these layers together to understand phenotypic pattern and their nuances, e.g. in the manifestation of genetic diseases. Recent advances in sequencing technologies enabled the parallel measurement of multiple omic layers from the same sample. Integrated analysis of these __multiomics__ data can help to unravel the underlying molecular mechanisms of regulation and their interactions.
+Molecular mechanisms are highly regulated at various levels. Different omic
+layers (genomics, transcriptomics, proteomics, metabolomics) interact and
+communicate with each other to establish specific phenotypes. Thus, it can be
+crucial to explore several of these layers together to understand phenotypic
+pattern and their nuances, e.g. in the manifestation of genetic diseases. Recent
+advances in sequencing technologies enabled the parallel measurement of multiple
+omic layers from the same sample. Integrated analysis of these **multiomics**
+data can help to unravel the underlying molecular mechanisms of regulation and
+their interactions.
 
 ## Multi Omics Digital Object System(MODOS)
 
 ### Features
 
-:::{image} ../img/multiomics.png
-   :align: right
-   :width: 200
-   :height: 200
-   :alt: multiomics
-:::
+:::{image} ../img/multiomics.png :align: right :width: 200 :height: 200 :alt:
+multiomics :::
 
-The main goal of `MODOS` is to enable collaborative analysis and data sharing of multiomics data. Typically multiomics data are large in size, diverse in their formats and object to secure access. Thus remote storage with regulated access can be key to enable data sharing and integrated analysis.
-Because of these requirements the `MODOS-api` provides the following __key features__:
+The main goal of `MODOS` is to enable collaborative analysis and data sharing of
+multiomics data. Typically multiomics data are large in size, diverse in their
+formats and object to secure access. Thus remote storage with regulated access
+can be key to enable data sharing and integrated analysis. Because of these
+requirements the `MODOS-api` provides the following **key features**:
 
 - queryable, linked metadata
 - data and metadata synchronisation
@@ -26,25 +33,31 @@ Because of these requirements the `MODOS-api` provides the following __key featu
 
 ### Object structure
 
-Internally, `MODOS` builds on the <a href="https://github.com/zarr-developers/zarr-python" target="_blank">zarr</a> file storage format, that allows storage and access of chunked, compressed, N-dimensional __arrays__ alongside their __metadata__ in __hierachical groups__. All metadata can be consolidated and exported separately for querying or listing purposes. Genomics data are not stored as arrays, but can be added to the `zarr` archive in <a href="https://samtools.github.io/hts-specs/CRAMv3.pdf" target="_blank">CRAM</a> format. CRAM is a reference-based compression format for alignment files:
+Internally, `MODOS` builds on the
+<a href="https://github.com/zarr-developers/zarr-python" target="_blank">zarr</a>
+file storage format, that allows storage and access of chunked, compressed,
+N-dimensional **arrays** alongside their **metadata** in **hierachical groups**.
+All metadata can be consolidated and exported separately for querying or listing
+purposes. Genomics data are not stored as arrays, but can be added to the `zarr`
+archive in
+<a href="https://samtools.github.io/hts-specs/CRAMv3.pdf" target="_blank">CRAM</a>
+format. CRAM is a reference-based compression format for alignment files:
 
-:::{image} ../img/digital-object.png
-   :align: center
-   :width: 600
-   :alt: digital-object
-:::
+:::{image} ../img/digital-object.png :align: center :width: 600 :alt:
+digital-object :::
 
 ### Remote storage
 
-:::{image} ../img/smoc-server.png
-   :align: right
-   :width: 270
-   :alt: smoc-server
+:::{image} ../img/smoc-server.png :align: right :width: 270 :alt: smoc-server
 :::
 
-The `MODOS-api` provides a server implementation to facilitate remote storage and access. This server consists of __3 main components__:
+The `MODOS-api` provides a server implementation to facilitate remote storage
+and access. This server consists of **3 main components**:
+
 - a webserver exposing a REST api to interact with remote objects
 - a htsget server to provide streaming access over network to CRAM files
 - s3 bucket to allow remote random access
 
-Detailed instructions about how to deploy can be found in the <a href="https://github.com/sdsc-ordes/modos-api/tree/main/deploy" target="_blank">MODOS-api github project -> deploy</a>.
+Detailed instructions about how to deploy can be found in the
+<a href="https://github.com/sdsc-ordes/modos-api/tree/main/deploy" target="_blank">MODOS-api
+github project -> deploy</a>.

--- a/docs/intro/quickstart.md
+++ b/docs/intro/quickstart.md
@@ -6,43 +6,48 @@ First install modos using pip or use docker to run modos within a container:
 
 ::::{tab-set}
 
-:::{tab-item} pip
-:sync: pip
+:::{tab-item} pip :sync: pip
+
 ```{code-block} console
 pip install git+https://github.com/sdsc-ordes/modos-api.git@main
 ```
+
 :::
 
-:::{tab-item} docker
-:sync: docker
+:::{tab-item} docker :sync: docker
+
 ```{code-block} console
 docker pull ghcr.io/sdsc-ordes/modos-api:latest
 ```
+
 :::
 
 ::::
 
-Next, you can use the modo-cli to build a new multiomics digital object (__modo__) with the id `ex`:
+Next, you can use the modo-cli to build a new multiomics digital object
+(**modo**) with the id `ex`:
 
-:::{note}
-You will be prompted to complete further modo metadata information.
-This command will generate the modo object in the current working directory. Use a relative path, if you want to store your object at a specific location, e.g. `modos create data/ex`
-:::
+:::{note} You will be prompted to complete further modo metadata information.
+This command will generate the modo object in the current working directory. Use
+a relative path, if you want to store your object at a specific location, e.g.
+`modos create data/ex` :::
 
 ::::{tab-set}
 
-:::{tab-item} pip
-:sync: pip
+:::{tab-item} pip :sync: pip
+
 ```{code-block} console
 modos create ex
 ```
+
 :::
 
-:::{tab-item} docker
-:sync: docker
+:::{tab-item} docker :sync: docker
+
 ```{code-block} console
 docker run -itv "${PWD}:/modo" ghcr.io/sdsc-ordes/modos-api:latest modos create modo/ex
 ```
+
 :::
 
 ::::
@@ -51,18 +56,20 @@ To check further commands e.g. to add omics elements or interact use:
 
 ::::{tab-set}
 
-:::{tab-item} pip
-:sync: pip
+:::{tab-item} pip :sync: pip
+
 ```{code-block} console
 modos --help
 ```
+
 :::
 
-:::{tab-item} docker
-:sync: docker
+:::{tab-item} docker :sync: docker
+
 ```{code-block} console
 docker run ghcr.io/sdsc-ordes/modos-api:latest --help
 ```
+
 :::
 
 ::::

--- a/docs/tutorials/modo_access.md
+++ b/docs/tutorials/modo_access.md
@@ -3,14 +3,15 @@
 There are multiple ways to use a `MODO` and interact with it's elements.
 
 (explore)=
+
 ## Explore a MODO and it's elements
 
 `MODO` metadata can be easily accessed via CLI or using the python api:
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 from modos.api import MODO
 
@@ -21,13 +22,15 @@ modo = MODO(path = "data/ex")
 modo.show_contents()
 # {'ex': {'@type': 'MODO', 'creation_date': '2024-02-19T00:00:00', 'description': ..}
 ```
+
 :::
 
-:::{tab-item} cli
-:sync: cli
+:::{tab-item} cli :sync: cli
+
 ```{code-block} console
 modos show "data/ex"
 ```
+
 :::
 
 ::::
@@ -36,8 +39,8 @@ The objects structure can be visualized by displaying the internal hierarchy:
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 modo.list_arrays()
 #/
@@ -50,10 +53,11 @@ modo.list_arrays()
 # └── sample
 #     └── sample1
 ```
+
 :::
 
-:::{tab-item} cli
-:sync: cli
+:::{tab-item} cli :sync: cli
+
 ```{code-block} console
 modos show --zarr "data/ex"
 #/
@@ -66,55 +70,63 @@ modos show --zarr "data/ex"
 # └── sample
 #     └── sample1
 ```
+
 :::
 
 ::::
 
-:::{note}
-`MODOS` internally uses <a href="https://zarr.readthedocs.io/en/stable/api/hierarchy.html" target="_blank">zarr's hierarchy groups</a>. Each sub-directory represents a new hierarchy group. Any array-like data can directly be stored within these hierarchy groups, while other file formats are stored separately.
-:::
+:::{note} `MODOS` internally uses
+<a href="https://zarr.readthedocs.io/en/stable/api/hierarchy.html" target="_blank">zarr's
+hierarchy groups</a>. Each sub-directory represents a new hierarchy group. Any
+array-like data can directly be stored within these hierarchy groups, while
+other file formats are stored separately. :::
 
 All files part of a `MODO` can be listed:
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 [fi for fi in modo.list_files()]
 # [PosixPath('data/ex/reference1.fa'), PosixPath('data/ex/demo1.cram')]
 ```
+
 :::
 
-:::{tab-item} cli
-:sync: cli
+:::{tab-item} cli :sync: cli
+
 ```{code-block} console
 modos show --files "data/ex"
 # data/ex/reference1.fa
 # data/ex/demo1.cram
 ```
+
 :::
 
 ::::
 
 (publish)=
+
 ## Publish a MODO as linked data
 
-A semantic artifact can be created from the digital object and published as linked data.
-In this process JSON metadata are converted to RDF and all relative paths are converted to URI's.
+A semantic artifact can be created from the digital object and published as
+linked data. In this process JSON metadata are converted to RDF and all relative
+paths are converted to URI's.
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 modo.knowledge_graph(uri_prefix="http://demo-data")
 # <Graph identifier=N1aa0d4f1f3d9428b9c01e703096c5c96 (<class 'rdflib.graph.Graph'>)>
 ```
+
 :::
 
-:::{tab-item} cli
-:sync: cli
+:::{tab-item} cli :sync: cli
+
 ```{code-block} console
 modos publish --base-uri "http://demo-data" "data/ex"
 # @prefix EDAM: <http://edamontology.org/> .
@@ -132,12 +144,16 @@ modos publish --base-uri "http://demo-data" "data/ex"
 #
 #     ...
 ```
+
 :::
 
 ::::
 
 ## Enrich metadata
-Genomic files such as cram files store relevant metadata, e.g. their reference sequences, in their header. These information can be automatically extracted and included into a `MODO`.
+
+Genomic files such as cram files store relevant metadata, e.g. their reference
+sequences, in their header. These information can be automatically extracted and
+included into a `MODO`.
 
 ```{code-block} python
 # Enrich modo

--- a/docs/tutorials/modo_arrays.md
+++ b/docs/tutorials/modo_arrays.md
@@ -1,21 +1,25 @@
 # Handling data arrays with MODOS
 
-Any count-like data, e.g protein abundances, RNA counts, metabolomic measurements, etc. can be stored as arrays in the `MODO`.
-The underlying <a href="https://github.com/zarr-developers/zarr-python" target="_blank">zarr</a> supports array creation as well as an interface to NumPy arrays.
-
+Any count-like data, e.g protein abundances, RNA counts, metabolomic
+measurements, etc. can be stored as arrays in the `MODO`. The underlying
+<a href="https://github.com/zarr-developers/zarr-python" target="_blank">zarr</a>
+supports array creation as well as an interface to NumPy arrays.
 
 ## Load data
 
 (pandas)=
+
 ### Using panda DataFrames
 
-Count-like data can usually be loaded into <a href="https://pandas.pydata.org/docs/reference/frame.html" target="_blank">pandas DataFrame</a>.
-To keep column names (__observations__) and row names (__variables__) both need to be stored in a separate numpy array first:
+Count-like data can usually be loaded into
+<a href="https://pandas.pydata.org/docs/reference/frame.html" target="_blank">pandas
+DataFrame</a>. To keep column names (**observations**) and row names
+(**variables**) both need to be stored in a separate numpy array first:
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 import pandas as pd
 import numpy as np
@@ -49,25 +53,24 @@ rna_array
 #        [ 334,  202,  218, ...]])
 
 ```
+
 ::::
 
-:::{warning}
-`to_numpy()` automatically removes row and column names from pandas DataFrames.
-It is important to store them separately, if they contain important information.
-:::
+:::{warning} `to_numpy()` automatically removes row and column names from pandas
+DataFrames. It is important to store them separately, if they contain important
+information. :::
 
-:::{note}
-Skip this section, if you already have your data in a NumPy array.
-:::
+:::{note} Skip this section, if you already have your data in a NumPy array. :::
 
 ## Add array element to a MODO
 
-Next, an element with the metadata describing the array can be added to the `MODO`:
+Next, an element with the metadata describing the array can be added to the
+`MODO`:
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 from modos.api import MODO
 import modos_schema.datamodel as model
@@ -92,21 +95,22 @@ modo.list_arrays()
 #     └── sample1
 
 ```
-:::
-::::
 
-:::{note}
-Skip this step, if you want to add the count data to an already existing element in the `MODO`.
-A helper function to facilitate adding the metadata element and numpy array in one step will also be added in future releases.
-:::
+::: ::::
+
+:::{note} Skip this step, if you want to add the count data to an already
+existing element in the `MODO`. A helper function to facilitate adding the
+metadata element and numpy array in one step will also be added in future
+releases. :::
 
 ## Add array to a MODO
+
 Finally all arrays can be added to the modo element:
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 
 modo.archive["data/rna1"].create_dataset("data", data=rna_array)
@@ -130,20 +134,24 @@ modo.list_arrays()
 #     └── sample1
 
 ```
+
 :::
 
 ::::
 
 (access)=
+
 ## Access Array data
 
 ### Load array as pandas DataFrame
-To access array data and analyse them the separated arrays can be loaded into a pandas dataframe:
+
+To access array data and analyse them the separated arrays can be loaded into a
+pandas dataframe:
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 import pandas as pd
 
@@ -153,5 +161,5 @@ var = modo.archive["data/rna1/var"][:]
 
 rna_counts = pd.DataFrame(rna_array, index=var, columns=obs)
 ```
-:::
-::::
+
+::: ::::

--- a/docs/tutorials/modo_provider.md
+++ b/docs/tutorials/modo_provider.md
@@ -1,63 +1,83 @@
 # Create and modify a MODO
 
-A `MODO` is a digital object to store, share and access omics data (genomics, transcriptomics, proteomics and metabolomics) and their metadata.
-Each `MODO` consists of a unique id, a creation and an update timestamp and some further optional metadata. Elements such as __data entities__, __samples__, __assays__ and __reference genomes__ can be linked and added to a `MODO`. The full data model can be found at <a href="https://sdsc-ordes.github.io/modos-schema/" target="_blank">modos-schema</a>.
+A `MODO` is a digital object to store, share and access omics data (genomics,
+transcriptomics, proteomics and metabolomics) and their metadata. Each `MODO`
+consists of a unique id, a creation and an update timestamp and some further
+optional metadata. Elements such as **data entities**, **samples**, **assays**
+and **reference genomes** can be linked and added to a `MODO`. The full data
+model can be found at
+<a href="https://sdsc-ordes.github.io/modos-schema/" target="_blank">modos-schema</a>.
 
 (scratch)=
+
 ## Generate a MODO from scratch
 
 (Create_scratch)=
+
 ### Create the object
 
-To create a new `MODO` you only need to specify the `path` where you want to generate the object. This will automatically generate a new <a href="https://zarr.readthedocs.io/en/stable/api/hierarchy.html" target="_blank">zarr group</a> at the specified `path`. If not specified explicitly the `MODO` id will be set to the `path` name.
+To create a new `MODO` you only need to specify the `path` where you want to
+generate the object. This will automatically generate a new
+<a href="https://zarr.readthedocs.io/en/stable/api/hierarchy.html" target="_blank">zarr
+group</a> at the specified `path`. If not specified explicitly the `MODO` id
+will be set to the `path` name.
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 from modos.api import MODO
 modo = MODO(path = "data/ex")
 modo
 # <modos.api.MODO object at 0x7df3131cb670>
 ```
+
 :::
 
-:::{tab-item} cli
-:sync: cli
+:::{tab-item} cli :sync: cli
+
 ```{code-block} console
 modos create data/ex
 ```
+
 :::
 
 ::::
 
-:::{note}
-If the specified path refers to an existing `MODO`, the existing object will be loaded instead of creating a new object and overwriting the existing object.
-Check [update](update) for details on how to update metadata of an existing `MODO`.
-:::
+:::{note} If the specified path refers to an existing `MODO`, the existing
+object will be loaded instead of creating a new object and overwriting the
+existing object. Check [update](update) for details on how to update metadata of
+an existing `MODO`. :::
 
-:::{warning}
-The specified `path` can not point to an existing object other than a `MODO` or the command will fail.
-:::
+:::{warning} The specified `path` can not point to an existing object other than
+a `MODO` or the command will fail. :::
 
 (add_scratch)=
+
 ### Add elements to the object
 
-To add omics data entities or further metadata to the object, you can add elements to the `MODO`.
-There are 4 different element types, that can be added:
+To add omics data entities or further metadata to the object, you can add
+elements to the `MODO`. There are 4 different element types, that can be added:
+
 - sample
 - assay
 - data
 - reference
 
-An element of the type data can be a <a href="https://sdsc-ordes.github.io/modos-schema/DataEntity/" target="_blank">DataEntity</a> or further spefied as an <a href="https://sdsc-ordes.github.io/modos-schema/AlignmentSet/" target="_blank">AlignmentSet</a>, an <a href="https://sdsc-ordes.github.io/modos-schema/Array/" target="_blank">Array</a>, a <a href="https://sdsc-ordes.github.io/modos-schema/VariantSet/" target="_blank">VariantSet</a>.
-
+An element of the type data can be a
+<a href="https://sdsc-ordes.github.io/modos-schema/DataEntity/" target="_blank">DataEntity</a>
+or further spefied as an
+<a href="https://sdsc-ordes.github.io/modos-schema/AlignmentSet/" target="_blank">AlignmentSet</a>,
+an
+<a href="https://sdsc-ordes.github.io/modos-schema/Array/" target="_blank">Array</a>,
+a
+<a href="https://sdsc-ordes.github.io/modos-schema/VariantSet/" target="_blank">VariantSet</a>.
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 from modos.api import MODO
 import modos_schema.datamodel as model
@@ -71,30 +91,34 @@ data = model.DataEntity(id="genomics1", name= "demo_genomics", description = "A 
 # Add element to modo
 modo.add_element(element = data, data_file="path/to/cram_file.cram")
 ```
+
 :::
 
-:::{tab-item} cli
-:sync: cli
+:::{tab-item} cli :sync: cli
+
 ```{code-block} console
 modos add --data-file path/to/cram_file.cram data/ex data
 ```
+
 :::
 
 ::::
 
-:::{note}
-To specify a file that should be associated with this object the `data-file` option can be used.
-In addition elements can be linked with each other, e.g. a `VariantSet` to a `ReferenceGenome` or a `DataEntity` to a `Sample` by using the `parent`/`part-of` option.
-:::
+:::{note} To specify a file that should be associated with this object the
+`data-file` option can be used. In addition elements can be linked with each
+other, e.g. a `VariantSet` to a `ReferenceGenome` or a `DataEntity` to a
+`Sample` by using the `parent`/`part-of` option. :::
 
-:::{warning}
-Files associated through the `data-file` option will be copied into the `MODO` at the path specified in the `data_path` attribute. For large files this can take some time.
-:::
+:::{warning} Files associated through the `data-file` option will be copied into
+the `MODO` at the path specified in the `data_path` attribute. For large files
+this can take some time. :::
 
 (file)=
+
 ## Generate a MODO from (yaml-)file
 
-Alternatively, a MODO and all associated elements can be specified in a `yaml-file`, such as the following `example.yaml`:
+Alternatively, a MODO and all associated elements can be specified in a
+`yaml-file`, such as the following `example.yaml`:
 
 ```{code-block} yaml
 # An example yaml file to generate a MODO.
@@ -134,50 +158,58 @@ Alternatively, a MODO and all associated elements can be specified in a `yaml-fi
   sex: Male
 ```
 
-All valid element types, their fields and potential links can be found in the <a href="https://sdsc-ordes.github.io/modos-schema/" target="_blank">modos-schema</a>.
+All valid element types, their fields and potential links can be found in the
+<a href="https://sdsc-ordes.github.io/modos-schema/" target="_blank">modos-schema</a>.
 
-Using this `example.yaml` a `MODO` and all specified associated elements can be generated in one command:
+Using this `example.yaml` a `MODO` and all specified associated elements can be
+generated in one command:
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 from modos.io import build_modo_from_file
 modo = build_modo_from_file(path = "path/to/example.yaml", object_directory = "data/ex")
 ```
+
 :::
 
-:::{tab-item} cli
-:sync: cli
+:::{tab-item} cli :sync: cli
+
 ```{code-block} console
 modos create --from-file "path/to/example.yaml" data/ex
 ```
+
 :::
 
 ::::
 
-
 (update)=
+
 ## Update or remove a MODO element
 
-All elements of a `MODO` can be added (see [Add elements to the object](add_scratch)) or removed at any timepoint using the `element id`:
+All elements of a `MODO` can be added (see
+[Add elements to the object](add_scratch)) or removed at any timepoint using the
+`element id`:
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 # Remove an associated element
 modo.remove_element("/data/genomics1")
 ```
+
 :::
 
-:::{tab-item} cli
-:sync: cli
+:::{tab-item} cli :sync: cli
+
 ```{code-block} console
 modos remove data/ex /data/genomics
 ```
+
 :::
 
 ::::

--- a/docs/tutorials/modo_remote.md
+++ b/docs/tutorials/modo_remote.md
@@ -1,11 +1,18 @@
 # Working with remote objects
 
-Remote storage can be key to share and collaborate on multiomics data. `MODOS` integrates with S3 object storage and <a href="https://academic.oup.com/bioinformatics/article/35/1/119/5040320" target="_blank">htsget</a> to allow remote storage, access and real-time secure streaming of genomic data.
-Most of the `MODOS-api`'s functionalities work with remotely stored objects in the same way as with local objects. The user only as to specify the `s3_endpoint` of the remote object store.
+Remote storage can be key to share and collaborate on multiomics data. `MODOS`
+integrates with S3 object storage and
+<a href="https://academic.oup.com/bioinformatics/article/35/1/119/5040320" target="_blank">htsget</a>
+to allow remote storage, access and real-time secure streaming of genomic data.
+Most of the `MODOS-api`'s functionalities work with remotely stored objects in
+the same way as with local objects. The user only as to specify the
+`s3_endpoint` of the remote object store.
 
 ## List remotely available MODO's
-Listing all available `MODOs` at a specific S3 endpoint (in this tutorial we will use http://localhost as example) will show `MODOs` in all buckets at that endpoint:
 
+Listing all available `MODOs` at a specific S3 endpoint (in this tutorial we
+will use http://localhost as example) will show `MODOs` in all buckets at that
+endpoint:
 
 ```{code-block} python
 import modos.remote as remo
@@ -16,6 +23,7 @@ remo.list_remote_items("http://localhost")
 ```
 
 ## Show metadata of a remote MODO
+
 For all or a specific `MODO` metadata can directly be displayed:
 
 ```{code-block} python
@@ -29,7 +37,9 @@ remo.get_metadata_from_remote("http://localhost", modo_id = "ex")
 ```
 
 ## Find a specific MODO and get it's S3 path
-There are different options to query a specific `MODO` and the __bucket name__ to load it from - fuzzy search or exact string matching:
+
+There are different options to query a specific `MODO` and the **bucket name**
+to load it from - fuzzy search or exact string matching:
 
 ```{code-block} python
 import modos.remote as remo
@@ -45,12 +55,13 @@ remo.get_s3_path("http://localhost", query="ex", exact_match = True)
 
 ## Intiantiate a remote MODO locally
 
-Remotely stored `MODOs` can be intiantiated by specifiying their remote endpoint and then and worked with as if they were stored locally.
+Remotely stored `MODOs` can be intiantiated by specifiying their remote endpoint
+and then and worked with as if they were stored locally.
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 from modos.api import MODO
 
@@ -61,10 +72,11 @@ modo=MODO(path= 'modos-demo/ex', s3_endpoint = 'http://localhost/s3')
 modo.metadata
 # {'ex': {'@type': 'MODO', 'creation_date': '2024-02-19T00:00:00', 'description': 'Dummy modo for tests.', 'has_assay': ..}}
 ```
+
 :::
 
-:::{tab-item} cli
-:sync: cli
+:::{tab-item} cli :sync: cli
+
 ```{code-block} console
 # Interact with remotly stored MODO
 modos show -s3 "http://localhost/s3" modos-demo/ex
@@ -74,23 +86,27 @@ modos show -s3 "http://localhost/s3" modos-demo/ex
 #   description: Dummy modo for tests.
 #   has_assay:
 ```
+
 :::
 
 ::::
 
-:::{note}
-The __bucket name__ and the __S3 endpoint url__ are specified separatly. The __bucket name__ is prepended to the `MODO`'s name in the same way as a local path, while the __S3 endpoint url__ needs to be specified specifically.
-:::
+:::{note} The **bucket name** and the **S3 endpoint url** are specified
+separatly. The **bucket name** is prepended to the `MODO`'s name in the same way
+as a local path, while the **S3 endpoint url** needs to be specified
+specifically. :::
 
 (generate_remote)=
+
 ## Generate and modify a MODO at a remote object store
 
-A `MODO` can be generated from scratch or from file in the same way as locally, by specifying the remote endpoint's url:
+A `MODO` can be generated from scratch or from file in the same way as locally,
+by specifying the remote endpoint's url:
 
 ::::{tab-set}
 
-:::{tab-item} python
-:sync: python
+:::{tab-item} python :sync: python
+
 ```{code-block} python
 from modos.api import MODO
 from pathlib import Path
@@ -101,18 +117,21 @@ config_ex = Path("path/to/ex.yaml")
 # Create a modo remotely
 modo = build_modo_from_file(config_ex, "modos-demo/ex", s3_endpoint= "http://localhost/s3")
 ```
+
 :::
 
-:::{tab-item} cli
-:sync: cli
+:::{tab-item} cli :sync: cli
+
 ```{code-block} console
 # Create a modo from file remotely
 modos create -s3 "http://localhost/s3" ----from-file "path/to/ex.yaml" modos-demo/ex3
 ```
+
 :::
 
 ::::
 
-:::{note}
-Similar to `MODO` creation, any other modifying functionality of the `modos-api`, (e.g.  `modos add`, `modos remove` or `MODO.add_element()`, `MODO.remove_element()`)can be performed on remotely stored objects by specifying the __S3 endpoint__ and __bucket name__ as path.
-:::
+:::{note} Similar to `MODO` creation, any other modifying functionality of the
+`modos-api`, (e.g. `modos add`, `modos remove` or `MODO.add_element()`,
+`MODO.remove_element()`)can be performed on remotely stored objects by
+specifying the **S3 endpoint** and **bucket name** as path. :::

--- a/docs/tutorials/tutorials.md
+++ b/docs/tutorials/tutorials.md
@@ -1,10 +1,5 @@
 # Tutorials
 
-:::{toctree}
-:maxdepth: 2
+:::{toctree} :maxdepth: 2
 
-modo_provider.md
-modo_access.md
-modo_remote.md
-modo_arrays.md
-:::
+modo_provider.md modo_access.md modo_remote.md modo_arrays.md :::


### PR DESCRIPTION
#  Description

Format all markdown docs with `prettier`.

# Reason for the Change

- All markdown documents should be formatted. I choose normally `prettier` because there is no better easier tool out there which works nicely. It adheres to `CommonMark` etc. Ok there is `pandoc` and other formatters. We can discuss that in BPA for language guidlines on `docs` maybe.
