### PR TITLE
chore: add issue templates for feature requests and bug reports.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,45 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug"]
+projects: ["sdsc-ordes/modos-api"]
+assignees:
+  - cmdoret
+  - almutlue
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: system
+    attributes:
+      label: What system are you using?
+      multiple: true
+      options:
+        - MacOS
+        - Linux distribution
+        - Microsoft Windows
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,68 @@
+name: Feature request
+description: Describe a new feature that is currently missing in modos-api.
+title: "[Feature request]: "
+labels: ["enhancement"]
+projects: ["sdsc-ordes/modos-api"]
+assignees:
+  - cmdoret
+  - almutlue
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A detailed explanation of the feature. This should include what the feature is, why it is needed, and how it is expected to improve the product or process.
+    validations:
+      required: true
+  - type: dropdown
+    id: importance
+    attributes:
+      label: Importance Level
+      description: An indication of the feature's importance from the strategic point of view. Please, do not take it as a priority level which will be determined as relative to the other features.
+      options:
+        - Low
+        - Medium
+        - High
+      default: 0
+    validations:
+      required: false
+  - type: dropdown
+    id: components
+    attributes:
+      label: Affected Components
+      multiple: true
+      options:
+        - api
+        - cli
+        - server setup
+        - data schema
+        - other
+      validations:
+        required: false
+  - type: textarea
+    id: technical
+    attributes:
+      label: Technical Requirements
+      description: Detailed technical specifications or requirements needed to implement the feature (if possible, otherwise completed by SDSC).
+      placeholder: ex. allow integration with zarr version 3
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Specific criteria or metrics for evaluating the success or effectiveness of the feature once implemented.
+    validations:
+      required: false


### PR DESCRIPTION
Adds issue templates for bug reports and feature requests.
These templates use [github issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) as they are mainly targeting external contributor/user and are not so much intended for internal issues.
