### PR TITLE
fix: consistent ids

### DIFF
--- a/data/ex/data.zarr/.zattrs
+++ b/data/ex/data.zarr/.zattrs
@@ -3,7 +3,7 @@
     "creation_date": "2024-02-19T00:00:00",
     "description": "Dummy modo for tests.",
     "has_assay": [
-        "assay1"
+        "assay/assay1"
     ],
     "id": "ex",
     "last_update_date": "2024-02-19T00:00:00",

--- a/data/ex/data.zarr/.zmetadata
+++ b/data/ex/data.zarr/.zmetadata
@@ -5,7 +5,7 @@
             "creation_date": "2024-02-19T00:00:00",
             "description": "Dummy modo for tests.",
             "has_assay": [
-                "assay1"
+                "assay/assay1"
             ],
             "id": "ex",
             "last_update_date": "2024-02-19T00:00:00",
@@ -22,11 +22,11 @@
             "@type": "Assay",
             "description": "Dummy assay for tests.",
             "has_data": [
-                "demo1",
+                "data/demo1",
                 "data/calls1"
             ],
             "has_sample": [
-                "sample1"
+                "sample/sample1"
             ],
             "name": "Assay 1",
             "omics_type": [
@@ -45,10 +45,10 @@
             "data_path": "calls1.bcf",
             "description": "variant calls for tests",
             "has_reference": [
-                "/reference/reference1"
+                "reference/reference1"
             ],
             "has_sample": [
-                "/sample/sample1"
+                "sample/sample1"
             ],
             "name": "Calls 1"
         },

--- a/data/ex/data.zarr/assay/assay1/.zattrs
+++ b/data/ex/data.zarr/assay/assay1/.zattrs
@@ -2,11 +2,11 @@
     "@type": "Assay",
     "description": "Dummy assay for tests.",
     "has_data": [
-        "demo1",
+        "data/demo1",
         "data/calls1"
     ],
     "has_sample": [
-        "sample1"
+        "sample/sample1"
     ],
     "name": "Assay 1",
     "omics_type": [

--- a/data/ex/data.zarr/data/calls1/.zattrs
+++ b/data/ex/data.zarr/data/calls1/.zattrs
@@ -4,10 +4,10 @@
     "data_path": "calls1.bcf",
     "description": "variant calls for tests",
     "has_reference": [
-        "/reference/reference1"
+        "reference/reference1"
     ],
     "has_sample": [
-        "/sample/sample1"
+        "sample/sample1"
     ],
     "name": "Calls 1"
 }

--- a/data/ex/data.zarr/data/demo1/.zattrs
+++ b/data/ex/data.zarr/data/demo1/.zattrs
@@ -4,10 +4,10 @@
     "data_path": "demo1.cram",
     "description": "Dummy data for tests",
     "has_reference": [
-        "reference1"
+        "reference/reference1"
     ],
     "has_sample": [
-        "sample1"
+        "sample/sample1"
     ],
     "name": "Demo 1"
 }

--- a/modos/api.py
+++ b/modos/api.py
@@ -249,7 +249,7 @@ class MODO:
         # Inferred from type
         type_name = UserElementType.from_object(element).value
         type_group = self.zarr[type_name]
-        element_path = f"{type_name}/{element.id}"
+        element_path = f"/{type_name}/{element.id}"
 
         # Update part_of (parent) relationship
         if part_of is not None:
@@ -306,7 +306,7 @@ class MODO:
         # Inferred from type inferred from type
         type_name = ElementType.from_object(element).value
         type_group = self.zarr[type_name]
-        element_path = f"{type_name}/{element.id}"
+        element_path = f"/{type_name}/{element.id}"
 
         if part_of is not None:
             partof_group = self.zarr[part_of]

--- a/modos/api.py
+++ b/modos/api.py
@@ -46,7 +46,7 @@ class MODO:
 
     # List identifiers of samples in the archive
     >>> demo.list_samples()
-    ['/sample/sample1']
+    ['sample/sample1']
 
     # List files in the archive
     >>> files = sorted(demo.list_files())
@@ -121,7 +121,7 @@ class MODO:
         for subgroup in root.groups():
             group_type = subgroup[0]
             for name, value in list_zarr_items(subgroup[1]):
-                group_attrs[f"/{group_type}/{name}"] = dict(value.attrs)
+                group_attrs[f"{group_type}/{name}"] = dict(value.attrs)
         return group_attrs
 
     def knowledge_graph(
@@ -130,7 +130,7 @@ class MODO:
         """Return an RDF graph of the metadata. All identifiers
         are converted to valid URIs if needed."""
         if uri_prefix is None:
-            uri_prefix = f"file://{self.path.name}"
+            uri_prefix = f"file://{self.path.name}/"
         kg = attrs_to_graph(self.metadata, uri_prefix=uri_prefix)
         return kg
 
@@ -161,7 +161,7 @@ class MODO:
         for row in res:
             for val in row:
                 samples.append(
-                    str(val).removeprefix(f"file://{self.path.name}")
+                    str(val).removeprefix(f"file://{self.path.name}/")
                 )
         return samples
 
@@ -249,7 +249,7 @@ class MODO:
         # Inferred from type
         type_name = UserElementType.from_object(element).value
         type_group = self.zarr[type_name]
-        element_path = f"/{type_name}/{element.id}"
+        element_path = f"{type_name}/{element.id}"
 
         # Update part_of (parent) relationship
         if part_of is not None:
@@ -306,7 +306,7 @@ class MODO:
         # Inferred from type inferred from type
         type_name = ElementType.from_object(element).value
         type_group = self.zarr[type_name]
-        element_path = f"/{type_name}/{element.id}"
+        element_path = f"{type_name}/{element.id}"
 
         if part_of is not None:
             partof_group = self.zarr[part_of]

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -34,6 +34,23 @@ def dict_to_instance(element: Mapping[str, Any]) -> Any:
     )
 
 
+def full_id(element_id: str) -> bool:
+    """Checks if an element_id contains the element type as prefix.
+
+    Examples
+    --------
+    >>> full_id("sample1")
+    False
+    >>> full_id("data/test")
+    True
+    >>> full_id("/assay/test_assay")
+    True
+    """
+    etypes = [elem.value + "/" for elem in ElementType]
+    extended_etypes = etypes + ["/" + etype for etype in etypes]
+    return element_id.startswith(tuple(extended_etypes))
+
+
 def set_haspart_relationship(
     child_class: str,
     child_path: str,
@@ -74,7 +91,8 @@ def update_haspart_id(
             haspart_type = get_slot_range(has_part)
             type_name = ElementType.from_model_name(haspart_type).value
             updated_ids = [
-                f"{type_name}/{id}" for id in getattr(element, has_part)
+                id if full_id(id) else f"{type_name}/{id}"
+                for id in getattr(element, has_part)
             ]
             setattr(element, has_part, updated_ids)
     return element

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -91,7 +91,7 @@ def update_haspart_id(
             haspart_type = get_slot_range(has_part)
             type_name = ElementType.from_model_name(haspart_type).value
             updated_ids = [
-                id if full_id(id) else f"/{type_name}/{id}"
+                id if is_full_id(id) else f"/{type_name}/{id}"
                 for id in getattr(element, has_part)
             ]
             setattr(element, has_part, updated_ids)

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -91,7 +91,7 @@ def update_haspart_id(
             haspart_type = get_slot_range(has_part)
             type_name = ElementType.from_model_name(haspart_type).value
             updated_ids = [
-                id if full_id(id) else f"{type_name}/{id}"
+                id if full_id(id) else f"/{type_name}/{id}"
                 for id in getattr(element, has_part)
             ]
             setattr(element, has_part, updated_ids)

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -91,7 +91,7 @@ def update_haspart_id(
             haspart_type = get_slot_range(has_part)
             type_name = ElementType.from_model_name(haspart_type).value
             updated_ids = [
-                id if is_full_id(id) else f"/{type_name}/{id}"
+                id if is_full_id(id) else f"{type_name}/{id}"
                 for id in getattr(element, has_part)
             ]
             setattr(element, has_part, updated_ids)

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -34,16 +34,16 @@ def dict_to_instance(element: Mapping[str, Any]) -> Any:
     )
 
 
-def full_id(element_id: str) -> bool:
+def is_full_id(element_id: str) -> bool:
     """Checks if an element_id contains the element type as prefix.
 
     Examples
     --------
-    >>> full_id("sample1")
+    >>> is_full_id("sample1")
     False
-    >>> full_id("data/test")
+    >>> is_full_id("data/test")
     True
-    >>> full_id("/assay/test_assay")
+    >>> is_full_id("/assay/test_assay")
     True
     """
     etypes = [elem.value + "/" for elem in ElementType]

--- a/tests/test_api_local.py
+++ b/tests/test_api_local.py
@@ -41,7 +41,7 @@ def test_add_data(data_entity, tmp_path):
 
 def test_add_to_parent(sample, test_modo):
     test_modo.add_element(sample, part_of="/assay/assay1")
-    assert "sample/test_sample" in test_modo.metadata["/assay/assay1"].get(
+    assert "/sample/test_sample" in test_modo.metadata["/assay/assay1"].get(
         "has_sample"
     )
 
@@ -55,8 +55,9 @@ def test_remove_element(test_modo):
 
 
 def test_remove_element_link_list(test_modo):
-    test_modo.remove_element("sample/sample1")
-    assert ["sample/sample1"] not in test_modo.metadata[
+    assert ["/sample/sample1"] in test_modo.metadata["/assay/assay1"].values()
+    test_modo.remove_element("/sample/sample1")
+    assert ["/sample/sample1"] not in test_modo.metadata[
         "/assay/assay1"
     ].values()
 
@@ -65,8 +66,8 @@ def test_remove_element_link_list(test_modo):
 
 
 def test_update_element(test_modo):
-    sample1 = model.Sample(id="sample/sample1", cell_type="Leukocytes")
-    test_modo.update_element("sample/sample1", sample1)
+    sample1 = model.Sample(id="/sample/sample1", cell_type="Leukocytes")
+    test_modo.update_element("/sample/sample1", sample1)
     assert (
         test_modo.metadata["/sample/sample1"].get("cell_type") == "Leukocytes"
     )

--- a/tests/test_api_local.py
+++ b/tests/test_api_local.py
@@ -29,7 +29,7 @@ def test_init_modo_from_yaml(tmp_path):
 def test_add_element(assay, tmp_path):
     modo = MODO(tmp_path)
     modo.add_element(assay)
-    assert "/assay/test_assay" in modo.metadata.keys()
+    assert "assay/test_assay" in modo.metadata.keys()
 
 
 def test_add_data(data_entity, tmp_path):
@@ -40,8 +40,8 @@ def test_add_data(data_entity, tmp_path):
 
 
 def test_add_to_parent(sample, test_modo):
-    test_modo.add_element(sample, part_of="/assay/assay1")
-    assert "/sample/test_sample" in test_modo.metadata["/assay/assay1"].get(
+    test_modo.add_element(sample, part_of="assay/assay1")
+    assert "sample/test_sample" in test_modo.metadata["assay/assay1"].get(
         "has_sample"
     )
 
@@ -51,14 +51,14 @@ def test_add_to_parent(sample, test_modo):
 
 def test_remove_element(test_modo):
     test_modo.remove_element("sample/sample1")
-    assert "/sample/sample1" not in test_modo.list_samples()
+    assert "sample/sample1" not in test_modo.list_samples()
 
 
 def test_remove_element_link_list(test_modo):
-    assert ["/sample/sample1"] in test_modo.metadata["/assay/assay1"].values()
-    test_modo.remove_element("/sample/sample1")
-    assert ["/sample/sample1"] not in test_modo.metadata[
-        "/assay/assay1"
+    assert ["sample/sample1"] in test_modo.metadata["assay/assay1"].values()
+    test_modo.remove_element("sample/sample1")
+    assert ["sample/sample1"] not in test_modo.metadata[
+        "assay/assay1"
     ].values()
 
 
@@ -66,10 +66,10 @@ def test_remove_element_link_list(test_modo):
 
 
 def test_update_element(test_modo):
-    sample1 = model.Sample(id="/sample/sample1", cell_type="Leukocytes")
-    test_modo.update_element("/sample/sample1", sample1)
+    sample1 = model.Sample(id="sample/sample1", cell_type="Leukocytes")
+    test_modo.update_element("sample/sample1", sample1)
     assert (
-        test_modo.metadata["/sample/sample1"].get("cell_type") == "Leukocytes"
+        test_modo.metadata["sample/sample1"].get("cell_type") == "Leukocytes"
     )
 
 
@@ -78,7 +78,7 @@ def test_update_element(test_modo):
 
 def test_enrich_metadata(test_modo):
     test_modo.enrich_metadata()
-    assert "/sequence/BA000007.3_bd7522" in test_modo.metadata.keys()
+    assert "sequence/BA000007.3_bd7522" in test_modo.metadata.keys()
 
 
 ## Stream cram

--- a/tests/test_api_remote.py
+++ b/tests/test_api_remote.py
@@ -28,7 +28,7 @@ def test_multi_modos(setup):
 @pytest.mark.slow
 def test_add_element(assay, remote_modo):
     remote_modo.add_element(assay)
-    assert "/assay/test_assay" in remote_modo.metadata.keys()
+    assert "assay/test_assay" in remote_modo.metadata.keys()
 
 
 @pytest.mark.slow
@@ -44,9 +44,9 @@ def test_add_data(data_entity, remote_modo):
 @pytest.mark.slow
 def test_remove_element(sample, remote_modo):
     remote_modo.add_element(sample)
-    assert "/sample/test_sample" in remote_modo.list_samples()
+    assert "sample/test_sample" in remote_modo.list_samples()
     remote_modo.remove_element("sample/test_sample")
-    assert "/sample/test_sample" not in remote_modo.list_samples()
+    assert "sample/test_sample" not in remote_modo.list_samples()
 
 
 ## Update element
@@ -60,6 +60,6 @@ def test_update_element(sample, remote_modo):
     )
     remote_modo.update_element("sample/test_sample", test_sample)
     assert (
-        remote_modo.metadata["/sample/test_sample"].get("description")
+        remote_modo.metadata["sample/test_sample"].get("description")
         == "A fake sample for test purposes"
     )

--- a/tests/test_cli_local.py
+++ b/tests/test_cli_local.py
@@ -43,7 +43,7 @@ def test_add_element(tmp_path, assay):
         cli, ["add", "-m", assay_json, str(tmp_path), "assay"]
     )
     assert result.exit_code == 0
-    assert "/assay/test_assay" in modo.metadata.keys()
+    assert "assay/test_assay" in modo.metadata.keys()
 
 
 def test_add_data(tmp_path, data_entity):
@@ -73,13 +73,13 @@ def test_add_to_parent(tmp_path, test_modo, sample):
             "-m",
             sample._as_json,
             "-p",
-            "/assay/assay1",
+            "assay/assay1",
             str(tmp_path),
             "sample",
         ],
     )
     assert result.exit_code == 0
-    assert "/sample/test_sample" in test_modo.metadata["/assay/assay1"].get(
+    assert "sample/test_sample" in test_modo.metadata["assay/assay1"].get(
         "has_sample"
     )
 
@@ -88,16 +88,16 @@ def test_add_to_parent(tmp_path, test_modo, sample):
 
 
 def test_remove_element(test_modo, tmp_path):
-    assert "/sample/sample1" in test_modo.list_samples()
-    result = runner.invoke(cli, ["remove", str(tmp_path), "/sample/sample1"])
+    assert "sample/sample1" in test_modo.list_samples()
+    result = runner.invoke(cli, ["remove", str(tmp_path), "sample/sample1"])
     assert result.exit_code == 0
-    assert "/sample/sample1" not in test_modo.list_samples()
+    assert "sample/sample1" not in test_modo.list_samples()
 
 
 def test_remove_element_link_list(test_modo, tmp_path):
-    assert "/sample/sample1" in test_modo.zarr["/assay/assay1"].attrs.get(
+    assert "sample/sample1" in test_modo.zarr["assay/assay1"].attrs.get(
         "has_sample"
     )
-    result = runner.invoke(cli, ["remove", str(tmp_path), "/sample/sample1"])
+    result = runner.invoke(cli, ["remove", str(tmp_path), "sample/sample1"])
     assert result.exit_code == 0
-    assert test_modo.zarr["/assay/assay1"].attrs["has_sample"] is None
+    assert test_modo.zarr["assay/assay1"].attrs["has_sample"] is None

--- a/tests/test_cli_local.py
+++ b/tests/test_cli_local.py
@@ -79,7 +79,7 @@ def test_add_to_parent(tmp_path, test_modo, sample):
         ],
     )
     assert result.exit_code == 0
-    assert "sample/test_sample" in test_modo.metadata["/assay/assay1"].get(
+    assert "/sample/test_sample" in test_modo.metadata["/assay/assay1"].get(
         "has_sample"
     )
 
@@ -88,15 +88,16 @@ def test_add_to_parent(tmp_path, test_modo, sample):
 
 
 def test_remove_element(test_modo, tmp_path):
-    result = runner.invoke(cli, ["remove", str(tmp_path), "sample/sample1"])
-    # assert result.exit_code == 0
+    assert "/sample/sample1" in test_modo.list_samples()
+    result = runner.invoke(cli, ["remove", str(tmp_path), "/sample/sample1"])
+    assert result.exit_code == 0
     assert "/sample/sample1" not in test_modo.list_samples()
 
 
 def test_remove_element_link_list(test_modo, tmp_path):
-    assert "sample/sample1" in test_modo.zarr["assay/assay1"].attrs.get(
+    assert "/sample/sample1" in test_modo.zarr["/assay/assay1"].attrs.get(
         "has_sample"
     )
-    result = runner.invoke(cli, ["remove", str(tmp_path), "sample/sample1"])
+    result = runner.invoke(cli, ["remove", str(tmp_path), "/sample/sample1"])
     assert result.exit_code == 0
-    assert test_modo.zarr["assay/assay1"].attrs["has_sample"] is None
+    assert test_modo.zarr["/assay/assay1"].attrs["has_sample"] is None


### PR DESCRIPTION
## Aim:
Use consistent ids across modos-api. 

## Changes:
- use "full_id" `/element_type/element_id` when returning any element id and within any relationship declaration (`modos.metadata()`, `has_part` relationships,`part_of` relationships)
- adapt tests
- adapt default uri in `modos.knowledgegraph`
