### PR TITLE
fix: client-side region-filter on htsget streams

### DIFF
--- a/modos/api.py
+++ b/modos/api.py
@@ -377,6 +377,8 @@ class MODO:
                     endpoint_type = "/reads/"
                 case "VCF" | "BCF":
                     endpoint_type = "/variants/"
+                case _:
+                    raise ValueError("Invalid file format.")
 
             # http://domain/s3 + bucket/modo/file.cram --> http://domain/htsget/reads/modo/file.cram
             # or               + bucket/modo/file.vcf.gz --> http://domain/htsget/variants/modo/file.vcf.gz

--- a/modos/cram.py
+++ b/modos/cram.py
@@ -108,6 +108,7 @@ def slice_remote_genomics(
     genome__iter = bytesio_to_iterator(
         htsget_response_buffer,
         file_format=in_fileformat,
+        region=region,
         reference_filename=reference_filename,
     )
 

--- a/modos/cram.py
+++ b/modos/cram.py
@@ -11,7 +11,6 @@ from pysam import (
 from urllib.parse import urlparse
 import modos_schema.datamodel as model
 
-import sys
 import re
 import htsget
 from .helpers import (

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -275,7 +275,7 @@ class GenomicFileSuffix(tuple, Enum):
 
 def file_to_pysam_object(
     path: str, fileformat: str, reference_filename: Optional[str] = None
-):
+) -> VariantFile | AlignmentFile:
     """Create a pysam AlignmentFile of VariantFile"""
     if fileformat == "CRAM":
         pysam_file = AlignmentFile(
@@ -293,6 +293,7 @@ def file_to_pysam_object(
 def bytesio_to_iterator(
     bytesio_buffer: BytesIO,
     file_format: str,
+    region: Optional[str],
     reference_filename: Optional[str] = None,
 ) -> Iterator[AlignedSegment | VariantRecord]:
     """Takes a BytesIO buffer and returns a pysam
@@ -311,11 +312,9 @@ def bytesio_to_iterator(
             fileformat=file_format,
             reference_filename=reference_filename,
         )
-
-        with pysam_file as in_file:
+        for record in pysam_file.fetch(*parse_region(region), until_eof=True):
             # Iterate over the alignments in the file
-            for line in in_file:
-                yield line
+            yield record
 
 
 def iter_to_file(

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -321,13 +321,16 @@ def bytesio_to_iterator(
             get_start = lambda r: r.reference_start
 
         for record in pysam_iter:
-            if region and get_chrom(record) != chrom:
+            if region is None:
+                yield record
                 continue
-            if region and (
-                (get_start(record) < start) or (get_start(record) > end)
-            ):
+
+            bad_chrom = get_chrom(record) != chrom
+            bad_start = start is not None and (get_start(record) < start)
+            bad_end = end is not None and (get_start(record) > end)
+
+            if any([bad_chrom, bad_start, bad_end]):
                 continue
-            # Iterate over the alignments in the file
             yield record
 
 

--- a/modos/helpers.py
+++ b/modos/helpers.py
@@ -321,9 +321,11 @@ def bytesio_to_iterator(
             get_start = lambda r: r.reference_start
 
         for record in pysam_iter:
-            if get_chrom(record) != chrom:
+            if region and get_chrom(record) != chrom:
                 continue
-            if get_start(record) < start or get_start(record) > end:
+            if region and (
+                (get_start(record) < start) or (get_start(record) > end)
+            ):
                 continue
             # Iterate over the alignments in the file
             yield record


### PR DESCRIPTION
This PR ensures records streamed from htsget match the query region by applying lazy filter on client side. This is because the htsget server only selects record at the bgzf block level, resulting in out-of-query records.

This is a quickfix and the streaming code will need refactor as it is not maintainable nor efficient.

Fixes #51 