### PR TITLE
fea: allow virtual-host-style s3 buckets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 ##################################################
 # Poetry setup
 ##################################################
-FROM python as poetry
+FROM python AS poetry
 
 WORKDIR /app
 # Install poetry
@@ -32,7 +32,7 @@ RUN poetry install --no-interaction --no-ansi -vvv
 ##################################################
 # modos setup
 ##################################################
-FROM python as runtime
+FROM python AS runtime
 ARG VERSION_BUILD
 ENV PATH="/app/.venv/bin:$PATH"
 COPY --from=poetry /app /app
@@ -45,7 +45,7 @@ USER modos_user
 LABEL org.opencontainers.image.source=https://github.com/sdsc-ordes/modos-api
 LABEL org.opencontainers.image.description="Serve multi-omics digital objects"
 LABEL org.opencontainers.image.licenses=Apache-2.0
-LABEL org.opencontainers.image.version ${VERSION_BUILD}
+LABEL org.opencontainers.image.version=${VERSION_BUILD}
 
 # Test run
 RUN modos --help

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -49,7 +49,6 @@ services:
       - MINIO_SERVER_ACCESS_KEY=${MINIO_SERVER_ACCESS_KEY:-user}
       - MINIO_SERVER_SECRET_KEY=${MINIO_SERVER_SECRET_KEY:-pass}
       - MINIO_DEFAULT_BUCKETS=${MINIO_DEFAULT_BUCKET:-modos-demo:public}
-      - CDK_DEFAULT_REGION='us-west-1'
 
 
   htsget:
@@ -68,7 +67,6 @@ services:
       - S3_LOCAL_URL=${S3_LOCAL_URL:-http://172.23.0.2:9000}
       - AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER:-minio}
       - AWS_SECRET_ACCESS_KEY=${MINIO_ROOT_PASSWORD:-miniosecret}
-      - CDK_DEFAULT_REGION='us-west-1'
     command: htsget-actix --config s3_storage.toml
 
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -84,4 +84,5 @@ services:
       - S3_PUBLIC_URL=${S3_PUBLIC_URL:-http://localhost/s3}
       - HTSGET_LOCAL_URL=${HTSGET_LOCAL_URL:-http://htsget:8080}
       - S3_BUCKET=${S3_BUCKET:-modos-demo}
+      - S3_ADDRESSING_STYLE=${S3_ADDRESSING_STYLE:-auto}
     command: uvicorn --host 0.0.0.0 --port 8000 --reload server:app

--- a/deploy/modos-server/server.py
+++ b/deploy/modos-server/server.py
@@ -9,7 +9,6 @@ available modos, as well as their metadata.
 
 import difflib
 import os
-import s3fs
 
 from fastapi import FastAPI
 from modos.api import MODO

--- a/deploy/modos-server/server.py
+++ b/deploy/modos-server/server.py
@@ -13,6 +13,7 @@ import s3fs
 
 from fastapi import FastAPI
 from modos.api import MODO
+from modos.storage import connect_s3
 
 
 S3_LOCAL_URL = os.environ["S3_LOCAL_URL"]
@@ -21,7 +22,7 @@ BUCKET = os.environ["S3_BUCKET"]
 HTSGET_LOCAL_URL = os.environ["HTSGET_LOCAL_URL"]
 
 app = FastAPI()
-minio = s3fs.S3FileSystem(anon=True, endpoint_url=S3_LOCAL_URL)
+minio = connect_s3(S3_LOCAL_URL, {"anon": True})
 
 
 @app.get("/list")

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -26,7 +26,7 @@ from .introspection import (
     load_schema,
 )
 from .io import build_modo_from_file, parse_instance
-from .storage import add_metadata_group, init_zarr
+from .storage import connect_s3
 
 
 class RdfFormat(str, Enum):
@@ -145,7 +145,7 @@ def create(
         raise ValueError(f"Directory already exists: {object_directory}")
 
     if s3_endpoint:
-        fs = s3fs.S3FileSystem(endpoint_url=s3_endpoint, anon=True)
+        fs = connect_s3(s3_endpoint, {"anon": True})
         if fs.exists(object_directory):
             raise ValueError(
                 f"Remote directory already exists: {object_directory}"


### PR DESCRIPTION
**Context:** depending on the S3 provider, buckets may be specified in path-style (domain/bucket/key), or virtual-host-style (bucket.domain/key). Modos uses botocore, which should autodetect which format is supported by the S3 server, however this detection fails depending on the provider.

**Changes:** Keep autodetect by default, but allow setting an environment variable (S3_ADDRESSING_STYLE) to force a specific bucket addressing style to "path" or "virtual".
