### PR TITLE
fix(api): update new values in update_element

### DIFF
--- a/modos/api.py
+++ b/modos/api.py
@@ -24,6 +24,7 @@ from .storage import (
 )
 from .helpers.schema import (
     class_from_name,
+    convert_to_basetype,
     dict_to_instance,
     ElementType,
     set_haspart_relationship,
@@ -368,9 +369,9 @@ class MODO:
         # in the zarr store, empty properties are not stored
         # in the linkml model, they present as empty lists/None.
         new_items = {
-            field: value
+            field: convert_to_basetype(value)
             for field, value in new._items()
-            if field not in attrs.keys()
+            if (field, convert_to_basetype(value)) not in attrs.items()
             and field != "id"
             and value is not None
             and value != []

--- a/modos/api.py
+++ b/modos/api.py
@@ -365,17 +365,20 @@ class MODO:
             )
 
         new = update_haspart_id(new)
+        new = json.loads(json_dumper.dumps(new))
 
         # in the zarr store, empty properties are not stored
         # in the linkml model, they present as empty lists/None.
         new_items = {
-            field: convert_to_basetype(value)
-            for field, value in new._items()
-            if (field, convert_to_basetype(value)) not in attrs.items()
+            field: value
+            for field, value in new.items()
+            if (field, value) not in attrs.items()
             and field != "id"
             and value is not None
             and value != []
         }
+        if not len(new_items):
+            return
         attrs.update(**new_items)
         self.update_date()
 

--- a/modos/api.py
+++ b/modos/api.py
@@ -24,7 +24,6 @@ from .storage import (
 )
 from .helpers.schema import (
     class_from_name,
-    convert_to_basetype,
     dict_to_instance,
     ElementType,
     set_haspart_relationship,

--- a/modos/helpers/schema.py
+++ b/modos/helpers/schema.py
@@ -6,7 +6,7 @@ and for converting instances to different representations.
 from enum import Enum
 from functools import lru_cache, reduce
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Union
 from urllib.parse import urlparse
 
 import zarr
@@ -285,3 +285,15 @@ def get_haspart_property(child_class: str) -> Optional[str]:
         if child_class in all_targets:
             return prop_name
     return None
+
+
+def convert_to_basetype(inst: Any) -> Union[str, list[str], None]:
+    match inst:
+        case str():
+            return inst
+        case list():
+            return [str(ele) for ele in inst]
+        case None:
+            return None
+        case _:
+            return str(inst)

--- a/modos/helpers/schema.py
+++ b/modos/helpers/schema.py
@@ -285,15 +285,3 @@ def get_haspart_property(child_class: str) -> Optional[str]:
         if child_class in all_targets:
             return prop_name
     return None
-
-
-def convert_to_basetype(inst: Any) -> Union[str, list[str], None]:
-    match inst:
-        case str():
-            return inst
-        case list():
-            return [str(ele) for ele in inst]
-        case None:
-            return None
-        case _:
-            return str(inst)

--- a/tests/test_api_local.py
+++ b/tests/test_api_local.py
@@ -83,12 +83,18 @@ def test_remove_modo(test_modo):
 ## Update element
 
 
-def test_update_element(test_modo):
+def test_update_element_new_attribute(test_modo):
     sample1 = model.Sample(id="sample/sample1", cell_type="Leukocytes")
     test_modo.update_element("sample/sample1", sample1)
     assert (
         test_modo.metadata["sample/sample1"].get("cell_type") == "Leukocytes"
     )
+
+
+def test_update_element_existing_attribute(test_modo):
+    sample1 = model.Sample(id="sample/sample1", sex="Female")
+    test_modo.update_element("sample/sample1", sample1)
+    assert test_modo.metadata["sample/sample1"].get("sex") == "Female"
 
 
 ## Enrich metadata


### PR DESCRIPTION
## Context
So far `update_element()` did not overwrite existing metadata attributes, but only add new attributes that did not exist before.
An example to reproduce this is in https://github.com/sdsc-ordes/modos-api/issues/81
The reason for this is that we only compare new vs existing keys here:
```python
new_items = {
            field: value
            for field, value in new._items()
            if field not in attrs.keys()
            and field != "id"
            and value is not None
            and value != []
        }
```
The problem when comparing values is that values in new._items() are sometimes from linkml models (`modos_schema.datamodel`) and can contain descriptions etc, so that they can not easily be compared.
Example:
```python
>>> import modos_schema.datamodel as model
>>> sample = model.Sample(id="sample1", collector= 'Foo university', sex= 'Female')

# see sex 
>>> {k:v for k, v in sample._items()}
{'id': 'sample1', 'name': 'Sample 1', 'description': 'A dummy sample for tests.', 'cell_type': None, 'source_material': None, 'sex': (text='Male', description='The male sex.'), 'taxon_id': [], 'collector': ['Foo university']}
``` 

## Proposed changes
I wrote a converter (`convert_to_basetype()`) to convert all values to standard classes before comparison. I tested it on all instances for the example modos, but I'm afraid it is still brittle. It would break, if any of the model classes can not be converted into a str or list of strings. Unfortunately, there is no converter method from linkml classes AFAIK and I also couldn't come up with another solution without bloating everything up? 
