### PR TITLE
feat(cli): update modo from yaml file

### DIFF
--- a/modos/api.py
+++ b/modos/api.py
@@ -502,11 +502,12 @@ class MODO:
                 modo.update_element(modo_ids[inst.id], inst)
             else:
                 modo.add_element(inst, **args)
-        if not no_remove:
-            modo_id = modo_dict.get("meta", {}).get("id") or modo.path.name
-            old_ids = [
-                id for id in modo_ids.keys() if id not in ids and id != modo_id
-            ]
-            for old_id in old_ids:
-                modo.remove_element(modo_ids[old_id])
+        if no_remove:
+            return modo
+        modo_id = modo_id = modo.zarr["/"].attrs["id"]
+        old_ids = [
+            id for id in modo_ids.keys() if id not in ids and id != modo_id
+        ]
+        for old_id in old_ids:
+            modo.remove_element(modo_ids[old_id])
         return modo

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -415,11 +415,12 @@ def update(
     object_directory: Annotated[Path, typer.Argument(...)],
     config_file: Annotated[
         Path,
-        typer.Argument(
-            ...,
+        typer.Option(
+            "--config",
+            "-c",
             help="File defining the updated modo. The file must be in json or yaml format.",
         ),
-    ] = None,
+    ],
     s3_endpoint: Annotated[
         Optional[str],
         typer.Option(

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -438,7 +438,7 @@ def update(
         ),
     ] = False,
 ):
-    """Update an modo based on a yaml file."""
+    """Update a modo based on a yaml file."""
 
     typer.echo(f"Updating {object_directory}.", err=True)
     modo = MODO.from_file(

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -410,6 +410,44 @@ def stream(
             sys.stdout.buffer.write(chunk)
 
 
+@cli.command()
+def update(
+    object_directory: Annotated[Path, typer.Argument(...)],
+    config_file: Annotated[
+        Path,
+        typer.Argument(
+            ...,
+            help="File defining the updated modo. The file must be in json or yaml format.",
+        ),
+    ] = None,
+    s3_endpoint: Annotated[
+        Optional[str],
+        typer.Option(
+            "--s3-endpoint",
+            "-s3",
+            help="Url to S3 endpoint that stores the modo.",
+        ),
+    ] = None,
+    no_remove: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--no-remove",
+            "-n",
+            help="Do not remove elements that are missing in the config_file.",
+        ),
+    ] = False,
+):
+    """Update an modo based on a yaml file."""
+
+    typer.echo(f"Updating {object_directory}.", err=True)
+    modo = MODO.from_file(
+        path=config_file,
+        object_directory=object_directory,
+        s3_endpoint=s3_endpoint,
+        no_remove=no_remove,
+    )
+
+
 # Generate a click group to autogenerate docs via sphinx-click:
 # https://github.com/tiangolo/typer/issues/200#issuecomment-795873331
 


### PR DESCRIPTION
### Objective:
Add cli function to group update modo based on a yaml file. By default, this function will update existing elements, add new elements and remove elements that are not specified in the yaml, but part of modo. `--no-remove` flag can be set to prevent deletion of elements.

### Notes:
- I think `modo.from_file()` should have the same behavior and by default remove objects that are not specified in the yaml any longer. 
- I realized that there is no need to specify the modo itself in the yaml file, as modo just needs the `object_directory` and we require `object_directory()` as input argument anyways.

### Limitations:
- I did not add an `--element-id` flag, as it is the same as running `--no-remove` with a yaml only specifying the element to change.

### Questions: 
I realized that  `modo.update_element()` does accept a `source-file` or `part-of` argument. So if you want to update files, you would have to first remove the element and then run `update`. This also means that in `modo.from_file()` and `modos update` changes in the `args` part of the yaml file will be ignored. Should we change this? And if yes should this be part of this PR or a new one?

