### PR TITLE
feat: streamline remote options

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 volumes:
   minio-data:
     driver: local

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -6,11 +6,7 @@ volumes:
 
 networks:
   modos-network:
-    external: false
-    ipam:
-      config:
-        - subnet: 172.23.0.0/16
-          gateway: 172.23.0.1
+    driver: bridge
 
 services:
 
@@ -29,8 +25,7 @@ services:
     ports:
       - "80:80"
     networks:
-      modos-network:
-        ipv4_address: 172.23.0.5
+      - modos-network
 
   minio:
     image: docker.io/bitnami/minio:2024
@@ -41,8 +36,7 @@ services:
     volumes:
       - minio-data:/bitnami/minio/data
     networks:
-      modos-network:
-        ipv4_address: 172.23.0.2
+      - modos-network
     environment:
       - MINIO_ROOT_USER=${MINIO_ROOT_USER:-minio}
       - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-miniosecret}
@@ -62,10 +56,9 @@ services:
       - "8080" # ticket server
       - "8081" # data block server
     networks:
-      modos-network:
-        ipv4_address: 172.23.0.3
+      - modos-network
     environment:
-      - ENDPOINT=${S3_LOCAL_URL:-http://172.23.0.2:9000}
+      - ENDPOINT=${S3_PUBLIC_URL:-http://localhost/s3}
       - BUCKET=${S3_BUCKET:-modos-demo}
       - S3_ADDRESSING_STYLE=${S3_ADDRESSING_STYLE:-auto}
       - AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER:-minio}
@@ -79,8 +72,7 @@ services:
     expose:
       - "8000"
     networks:
-      modos-network:
-        ipv4_address: 172.23.0.4
+      - modos-network
     environment:
       - S3_LOCAL_URL=${S3_LOCAL_URL:-http://minio:9000}
       - S3_PUBLIC_URL=${S3_PUBLIC_URL:-http://localhost/s3}

--- a/deploy/modos-server/server.py
+++ b/deploy/modos-server/server.py
@@ -21,7 +21,7 @@ BUCKET = os.environ["S3_BUCKET"]
 HTSGET_LOCAL_URL = os.environ["HTSGET_LOCAL_URL"]
 
 app = FastAPI()
-minio = connect_s3(S3_LOCAL_URL, {"anon": True})
+minio = connect_s3(S3_LOCAL_URL, {"anon": True})  # type: ignore
 
 
 @app.get("/list")
@@ -38,7 +38,7 @@ def gather_metadata():
     meta = {}
 
     for modo in minio.ls(BUCKET, refresh=True):
-        meta.update(MODO(path=modo, s3_endpoint=S3_LOCAL_URL).metadata)
+        meta.update(MODO(path=modo, endpoint=S3_LOCAL_URL).metadata)  # type: ignore
 
     return meta
 

--- a/modos/__init__.py
+++ b/modos/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata as metadata
+
+__version__ = metadata.version(__name__)

--- a/modos/api.py
+++ b/modos/api.py
@@ -103,10 +103,9 @@ class MODO:
         source_uri: Optional[str] = None,
         endpoint: Optional[HttpUrl] = None,
         s3_kwargs: Optional[dict[str, Any]] = None,
-        services: Optional[dict[str, HttpUrl]] = None 
+        services: Optional[dict[str, HttpUrl]] = None,
     ):
         self.endpoint = EndpointManager(endpoint, services or {})
-
 
         if self.endpoint.s3:
             self.storage = S3Storage(Path(path), self.endpoint.s3, s3_kwargs)

--- a/modos/api.py
+++ b/modos/api.py
@@ -515,10 +515,9 @@ class MODO:
 
         modo = cls(
             path=object_directory,
-            s3_endpoint=s3_endpoint,
-            s3_kwargs=s3_kwargs or {"anon": True},
             endpoint=endpoint,
             services=services,
+            s3_kwargs=s3_kwargs or {"anon": True},
             **modo_dict.get("meta", {}),
             **modo_dict.get("args", {}),
         )

--- a/modos/api.py
+++ b/modos/api.py
@@ -484,7 +484,7 @@ class MODO:
     def from_file(
         cls,
         config_path: Path,
-        object_path: Path,
+        object_path: str,
         endpoint: Optional[HttpUrl] = None,
         s3_kwargs: Optional[dict] = None,
         services: Optional[dict[str, HttpUrl]] = None,

--- a/modos/api.py
+++ b/modos/api.py
@@ -75,7 +75,6 @@ class MODO:
         _s3_endpoint: Optional[HttpUrl] = None,
         _htsget_endpoint: Optional[HttpUrl] = None,
     ):
-
         self.endpoint = endpoint
 
         # manually specify endpoints (test/debug)

--- a/modos/api.py
+++ b/modos/api.py
@@ -448,7 +448,7 @@ class MODO:
         if Path(file_path) not in self.list_files():
             raise ValueError(f"{file_path} not found in {self.path}.")
 
-        if self.endpoint:
+        if self.htsget_endpoint:
             # http://domain/s3 + bucket/modo/file.cram --> http://domain/htsget/reads/modo/file.cram
             # or               + bucket/modo/file.vcf.gz --> http://domain/htsget/variants/modo/file.vcf.gz
             con = HtsgetConnection(

--- a/modos/api.py
+++ b/modos/api.py
@@ -105,7 +105,6 @@ class MODO:
         s3_kwargs: Optional[dict[str, Any]] = None,
         services: Optional[dict[str, HttpUrl]] = None 
     ):
-        # manually specify endpoints (test/debug)
         self.endpoint = EndpointManager(endpoint, services or {})
 
 

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -437,6 +437,7 @@ def callback(
     """Multi-Omics Digital Objects command line interface."""
     ...
 
+
 # Generate a click group to autogenerate docs via sphinx-click:
 # https://github.com/tiangolo/typer/issues/200#issuecomment-795873331
 

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -45,6 +45,14 @@ class RdfFormat(str, Enum):
 
 cli = typer.Typer(add_completion=False)
 
+OBJECT_PATH_ARG = Annotated[
+    Path,
+    typer.Argument(
+        ...,
+        help="Path to the digital object. Remote paths should have format s3://bucket/path",
+    ),
+]
+
 
 def prompt_for_slot(slot_name: str, prefix: str = "", optional: bool = False):
     """Prompt for a slot value."""
@@ -119,7 +127,7 @@ def prompt_for_slots(
 @cli.command()
 def create(
     ctx: typer.Context,
-    object_path: Annotated[Path, typer.Argument(...)],
+    object_path: OBJECT_PATH_ARG,
     from_file: Annotated[
         Optional[Path],
         typer.Option(
@@ -170,7 +178,7 @@ def create(
 @cli.command()
 def remove(
     ctx: typer.Context,
-    object_path: Annotated[Path, typer.Argument(...)],
+    object_path: OBJECT_PATH_ARG,
     element_id: Annotated[
         str,
         typer.Argument(
@@ -213,7 +221,7 @@ def remove(
 @cli.command()
 def add(
     ctx: typer.Context,
-    object_path: Annotated[Path, typer.Argument(...)],
+    object_path: OBJECT_PATH_ARG,
     element_type: Annotated[
         UserElementType,
         typer.Argument(
@@ -275,7 +283,7 @@ def add(
 @cli.command()
 def show(
     ctx: typer.Context,
-    object_path: Annotated[Path, typer.Argument(...)],
+    object_path: OBJECT_PATH_ARG,
     zarr: Annotated[
         bool,
         typer.Option(
@@ -313,7 +321,7 @@ def show(
 @cli.command()
 def publish(
     ctx: typer.Context,
-    object_path: Annotated[Path, typer.Argument(...)],
+    object_path: OBJECT_PATH_ARG,
     output_format: Annotated[RdfFormat, typer.Option(...)] = RdfFormat.TURTLE,
     base_uri: Annotated[Optional[str], typer.Option(...)] = None,
 ):
@@ -373,7 +381,7 @@ def stream(
 @cli.command()
 def update(
     ctx: typer.Context,
-    object_path: Annotated[Path, typer.Argument(...)],
+    object_path: OBJECT_PATH_ARG,
     config_file: Annotated[
         Path,
         typer.Option(

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -143,7 +143,7 @@ def create(
     endpoint = ctx.obj.endpoint
     # Initialize object's directory
     if endpoint:
-        s3 = list_endpoints(endpoint)["s3"]  # type: ignore
+        s3 = EndpointManager(endpoint).s3
         fs = connect_s3(s3, {"anon": True})  # type: ignore
         if fs.exists(object_directory):
             raise ValueError(

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -155,7 +155,7 @@ def create(
         fs = connect_s3(s3, {"anon": True})  # type: ignore
         if fs.exists(object_path):
             raise ValueError(f"Remote directory already exists: {object_path}")
-    elif object_path.exists():
+    elif Path(object_path).exists():
         raise ValueError(f"Directory already exists: {object_path}")
 
     # Obtain object's metadata and create object

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -28,10 +28,10 @@ from .helpers.schema import (
 )
 
 from . import __version__
-from .remote import list_endpoints
 from .genomics.htsget import HtsgetConnection
 from .genomics.region import Region
 from .io import parse_instance
+from .remote import EndpointManager
 from .storage import connect_s3
 
 
@@ -399,7 +399,7 @@ def stream(
 
 
     Example:
-    modos stream -s3 http://localhost/s3 my-bucket/ex-modo/demo1.cram
+    modos -e http://modos.example.org stream  my-bucket/ex-modo/demo1.cram
     """
     _region = Region.from_ucsc(region) if region else None
 
@@ -410,7 +410,9 @@ def stream(
     if not endpoint:
         raise ValueError("Streaming requires a remote endpoint.")
 
-    htsget_endpoint = list_endpoints(endpoint)["htsget"]  # type: ignore
+    htsget_endpoint = EndpointManager(endpoint).htsget #type: ignore
+    if not htsget_endpoint:
+        raise ValueError("No htsget service found.")
 
     con = HtsgetConnection(htsget_endpoint, source, _region)
     with con.open() as f:

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -46,7 +46,7 @@ class RdfFormat(str, Enum):
 cli = typer.Typer(add_completion=False)
 
 OBJECT_PATH_ARG = Annotated[
-    Path,
+    str,
     typer.Argument(
         ...,
         help="Path to the digital object. Remote paths should have format s3://bucket/path",

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -410,7 +410,7 @@ def stream(
     if not endpoint:
         raise ValueError("Streaming requires a remote endpoint.")
 
-    htsget_endpoint = EndpointManager(endpoint).htsget #type: ignore
+    htsget_endpoint = EndpointManager(endpoint).htsget  # type: ignore
     if not htsget_endpoint:
         raise ValueError("No htsget service found.")
 

--- a/modos/genomics/htsget.py
+++ b/modos/genomics/htsget.py
@@ -36,7 +36,6 @@ References
 
 import base64
 from collections import deque
-from dataclasses import dataclass
 from functools import cached_property
 import io
 from pathlib import Path
@@ -45,6 +44,8 @@ import tempfile
 from typing import Optional, Iterator
 from urllib.parse import urlparse, parse_qs
 
+from pydantic import HttpUrl, validate_call
+from pydantic.dataclasses import dataclass
 import pysam
 import requests
 
@@ -52,7 +53,10 @@ from .region import Region
 from .formats import GenomicFileSuffix, read_pysam
 
 
-def build_htsget_url(host: str, path: Path, region: Optional[Region]) -> str:
+@validate_call
+def build_htsget_url(
+    host: HttpUrl, path: Path, region: Optional[Region]
+) -> str:
     """Build an htsget URL from a host, path, and region.
 
     Examples
@@ -77,7 +81,8 @@ def build_htsget_url(host: str, path: Path, region: Optional[Region]) -> str:
     return url
 
 
-def parse_htsget_url(url: str) -> tuple[str, Path, Optional[Region]]:
+@validate_call
+def parse_htsget_url(url: HttpUrl) -> tuple[str, Path, Optional[Region]]:
     """Given a URL to an htsget resource, extract the host, path, and region."""
     parsed = urlparse(url)
     query = parse_qs(parsed.query)
@@ -217,7 +222,7 @@ class HtsgetConnection:
     It allows to open a stream to the resource and lazily fetch data from it.
     """
 
-    host: str
+    host: HttpUrl
     path: Path
     region: Optional[Region]
 

--- a/modos/genomics/htsget.py
+++ b/modos/genomics/htsget.py
@@ -256,7 +256,7 @@ class HtsgetConnection:
         return cls(host, path, region=region)
 
     def to_pysam(
-        self, reference_filename: str = None
+        self, reference_filename: Optional[str] = None
     ) -> Iterator[pysam.AlignedSegment | pysam.VariantRecord]:
         """Convert the stream to a pysam object."""
 

--- a/modos/genomics/htsget.py
+++ b/modos/genomics/htsget.py
@@ -75,7 +75,7 @@ def build_htsget_url(
     stem = path.with_suffix("") if path.name.endswith("gz") else path
     stem = stem.with_suffix("")
 
-    url = f"{host}/{endpoint}/{stem}?format={format.name}"
+    url = f"{host}{endpoint}/{stem}?format={format.name}"
     if region:
         url += f"&{region.to_htsget_query()}"
     return url

--- a/modos/remote.py
+++ b/modos/remote.py
@@ -1,7 +1,8 @@
 """Functions related to server storage handling"""
 
+from dataclasses import field
 from pydantic import HttpUrl, validate_call
-from pydantic.dataclasses import dataclass, field
+from pydantic.dataclasses import dataclass
 import requests
 from typing import Mapping, Optional
 
@@ -24,22 +25,18 @@ class EndpointManager:
     >>> ex = EndpointManager(modos="http://modos.example.org") # doctest: +SKIP
     >>> ex.list() # doctest: +SKIP
     {
-      "s3": "http://s3.example.org",
-      "htsget": "http://htsget.example.org"
+      's3: Url('http://s3.example.org/'),
+      'htsget': Url('http://htsget.example.org/')
     }
-    >>> ex.s3 # doctest: +SKIP
-    http://htsget.example.org 
+    >>> ex.htsget # doctest: +SKIP
+    Url('http://htsget.example.org/')
     >>> ex = EndpointManager(services={"s3": "http://s3.example.org"})
     >>> ex.s3
-    {"s3": "http://s3.example.org"}
+    Url('http://s3.example.org/')
 
     """
     modos: Optional[HttpUrl] = None
     services: dict[str, HttpUrl] = field(default_factory=dict)
-
-    def __post_init__(self):
-        if self.modos is None and not self.services:
-            raise ValueError("Either modos or services must be provided")
 
     def list(self) -> dict[str, HttpUrl]:
         """List available endpoints."""

--- a/modos/remote.py
+++ b/modos/remote.py
@@ -1,10 +1,11 @@
 """Functions related to server storage handling"""
 
 from dataclasses import field
+from typing import Mapping, Optional
+
 from pydantic import HttpUrl, validate_call
 from pydantic.dataclasses import dataclass
 import requests
-from typing import Mapping, Optional
 
 
 @dataclass(frozen=True)
@@ -86,6 +87,11 @@ def get_metadata_from_remote(
             ) from e
     else:
         return meta
+
+
+def is_s3_path(path: str):
+    """Check if a path is an S3 path"""
+    return path.startswith("s3://")
 
 
 @validate_call

--- a/modos/remote.py
+++ b/modos/remote.py
@@ -8,17 +8,17 @@ from typing import Mapping, Optional
 @validate_call
 def list_endpoints(url: HttpUrl) -> dict[str, HttpUrl]:
     """List all available endpoints on a remote modo server"""
-    return requests.get(url=f"{url}/endpoints").json()
+    return requests.get(url=str(url)).json()
 
 
 @validate_call
-def list_remote_items(remote_url: HttpUrl) -> list[HttpUrl]:
-    return requests.get(url=f"{remote_url}/list").json()
+def list_remote_items(url: HttpUrl) -> list[HttpUrl]:
+    return requests.get(url=f"{url}/list").json()
 
 
 @validate_call
 def get_metadata_from_remote(
-    remote_url: HttpUrl, modo_id: Optional[str] = None
+    url: HttpUrl, modo_id: Optional[str] = None
 ) -> Mapping:
     """Function to access metadata from one specific or all modos on a remote server
 
@@ -29,7 +29,7 @@ def get_metadata_from_remote(
     id
         id of the modo to retrieve metadata from. Will return all if not specified (default).
     """
-    meta = requests.get(url=f"{remote_url}/meta").json()
+    meta = requests.get(url=f"{url}/meta").json()
     if modo_id is not None:
         try:
             return meta[modo_id]
@@ -42,9 +42,7 @@ def get_metadata_from_remote(
 
 
 @validate_call
-def get_s3_path(
-    remote_url: HttpUrl, query: str, exact_match: bool = False
-) -> list:
+def get_s3_path(url: HttpUrl, query: str, exact_match: bool = False) -> list:
     """Request public S3 path of a specific modo or all modos matching the query string
     Parameters
     ----------
@@ -56,6 +54,6 @@ def get_s3_path(
         if True only modos with exactly that id will be returned, otherwise (default) all matching modos
     """
     return requests.get(
-        url=f"{remote_url}/get",
+        url=f"{url}/get",
         params={"query": query, "exact_match": exact_match},
     ).json()

--- a/modos/remote.py
+++ b/modos/remote.py
@@ -1,14 +1,22 @@
 """Functions related to server storage handling"""
 
-from pydantic import HttpUrl
+from pydantic import HttpUrl, validate_call
 import requests
 from typing import Mapping, Optional
 
 
+@validate_call
+def list_endpoints(url: HttpUrl) -> dict[str, HttpUrl]:
+    """List all available endpoints on a remote modo server"""
+    return requests.get(url=f"{url}/endpoints").json()
+
+
+@validate_call
 def list_remote_items(remote_url: HttpUrl) -> list[HttpUrl]:
-    return requests.get(url=remote_url + "/list").json()
+    return requests.get(url=f"{remote_url}/list").json()
 
 
+@validate_call
 def get_metadata_from_remote(
     remote_url: HttpUrl, modo_id: Optional[str] = None
 ) -> Mapping:
@@ -21,7 +29,7 @@ def get_metadata_from_remote(
     id
         id of the modo to retrieve metadata from. Will return all if not specified (default).
     """
-    meta = requests.get(url=remote_url + "/meta").json()
+    meta = requests.get(url=f"{remote_url}/meta").json()
     if modo_id is not None:
         try:
             return meta[modo_id]
@@ -33,6 +41,7 @@ def get_metadata_from_remote(
         return meta
 
 
+@validate_call
 def get_s3_path(
     remote_url: HttpUrl, query: str, exact_match: bool = False
 ) -> list:
@@ -47,6 +56,6 @@ def get_s3_path(
         if True only modos with exactly that id will be returned, otherwise (default) all matching modos
     """
     return requests.get(
-        url=remote_url + "/get",
+        url=f"{remote_url}/get",
         params={"query": query, "exact_match": exact_match},
     ).json()

--- a/modos/remote.py
+++ b/modos/remote.py
@@ -6,6 +6,7 @@ from pydantic.dataclasses import dataclass
 import requests
 from typing import Mapping, Optional
 
+
 @dataclass(frozen=True)
 class EndpointManager:
     """Handle modos server endpoints.
@@ -19,7 +20,7 @@ class EndpointManager:
         URL to the modos server.
     services
         Mapping of services to their urls.
-    
+
     Examples
     --------
     >>> ex = EndpointManager(modos="http://modos.example.org") # doctest: +SKIP
@@ -35,6 +36,7 @@ class EndpointManager:
     Url('http://s3.example.org/')
 
     """
+
     modos: Optional[HttpUrl] = None
     services: dict[str, HttpUrl] = field(default_factory=dict)
 
@@ -54,7 +56,6 @@ class EndpointManager:
     @property
     def htsget(self) -> Optional[HttpUrl]:
         return self.list().get("htsget")
-
 
 
 @validate_call

--- a/modos/storage.py
+++ b/modos/storage.py
@@ -123,7 +123,7 @@ class S3Path:
     )
     url: str = Field(
         ...,
-        json_schema_extra = {"strip_whitespace":True},  # type: ignore
+        json_schema_extra={"strip_whitespace": True},  # type: ignore
         pattern=_s3_pattern,
         min_length=8,
         max_length=1023,

--- a/modos/storage.py
+++ b/modos/storage.py
@@ -123,7 +123,7 @@ class S3Path:
     )
     url: str = Field(
         ...,
-        strip_whitespace=True,  # type: ignore
+        json_schema_extra = {"strip_whitespace":True},  # type: ignore
         pattern=_s3_pattern,
         min_length=8,
         max_length=1023,

--- a/modos/storage.py
+++ b/modos/storage.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import shutil
 from typing import Any, Generator, Optional
 
+from pydantic import HttpUrl
 import s3fs
 import zarr
 import zarr.hierarchy as zh
@@ -93,8 +94,8 @@ class S3Storage(Storage):
     def __init__(
         self,
         path: Path,
-        s3_endpoint: str,
-        s3_kwargs: dict[str, Any],
+        s3_endpoint: HttpUrl,
+        s3_kwargs: Optional[dict[str, Any]] = None,
     ):
         self._path = Path(path)
         self.endpoint = s3_endpoint
@@ -162,7 +163,9 @@ def init_zarr(zarr_store: zarr.storage.Store) -> zh.Group:
     return data
 
 
-def connect_s3(endpoint: str, s3_kwargs: dict[str, Any]) -> s3fs.S3FileSystem:
+def connect_s3(
+    endpoint: HttpUrl, s3_kwargs: dict[str, Any]
+) -> s3fs.S3FileSystem:
     return s3fs.S3FileSystem(
         endpoint_url=endpoint,
         config_kwargs={"s3": {"addressing_style": S3_ADDRESSING_STYLE}},

--- a/modos/storage.py
+++ b/modos/storage.py
@@ -102,7 +102,7 @@ class S3Storage(Storage):
         s3_opts = s3_kwargs or {"anon": True}
         fs = connect_s3(s3_endpoint, s3_opts)
         if fs.exists(str(self.path / ZARR_ROOT)):
-            zarr_s3_opts = s3_opts | {"endpoint_url": s3_endpoint}
+            zarr_s3_opts = s3_opts | {"endpoint_url": str(s3_endpoint)}
 
             self._zarr = zarr.convenience.open(
                 f"s3://{path}/{ZARR_ROOT}",
@@ -167,7 +167,7 @@ def connect_s3(
     endpoint: HttpUrl, s3_kwargs: dict[str, Any]
 ) -> s3fs.S3FileSystem:
     return s3fs.S3FileSystem(
-        endpoint_url=endpoint,
+        endpoint_url=str(endpoint),
         config_kwargs={"s3": {"addressing_style": S3_ADDRESSING_STYLE}},
         **s3_kwargs,
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1951,109 +1951,122 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.7.3"
+version = "2.8.2"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.7.3-py3-none-any.whl", hash = "sha256:ea91b002777bf643bb20dd717c028ec43216b24a6001a280f83877fd2655d0b4"},
-    {file = "pydantic-2.7.3.tar.gz", hash = "sha256:c46c76a40bb1296728d7a8b99aa73dd70a48c3510111ff290034f860c99c419e"},
+    {file = "pydantic-2.8.2-py3-none-any.whl", hash = "sha256:73ee9fddd406dc318b885c7a2eab8a6472b68b8fb5ba8150949fc3db939f23c8"},
+    {file = "pydantic-2.8.2.tar.gz", hash = "sha256:6f62c13d067b0755ad1c21a34bdd06c0c12625a22b0fc09c6b149816604f7c2a"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.4.0"
-pydantic-core = "2.18.4"
-typing-extensions = ">=4.6.1"
+pydantic-core = "2.20.1"
+typing-extensions = [
+    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
+    {version = ">=4.6.1", markers = "python_version < \"3.13\""},
+]
 
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
 
 [[package]]
 name = "pydantic-core"
-version = "2.18.4"
+version = "2.20.1"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_core-2.18.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:f76d0ad001edd426b92233d45c746fd08f467d56100fd8f30e9ace4b005266e4"},
-    {file = "pydantic_core-2.18.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:59ff3e89f4eaf14050c8022011862df275b552caef8082e37b542b066ce1ff26"},
-    {file = "pydantic_core-2.18.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a55b5b16c839df1070bc113c1f7f94a0af4433fcfa1b41799ce7606e5c79ce0a"},
-    {file = "pydantic_core-2.18.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4d0dcc59664fcb8974b356fe0a18a672d6d7cf9f54746c05f43275fc48636851"},
-    {file = "pydantic_core-2.18.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8951eee36c57cd128f779e641e21eb40bc5073eb28b2d23f33eb0ef14ffb3f5d"},
-    {file = "pydantic_core-2.18.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4701b19f7e3a06ea655513f7938de6f108123bf7c86bbebb1196eb9bd35cf724"},
-    {file = "pydantic_core-2.18.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e00a3f196329e08e43d99b79b286d60ce46bed10f2280d25a1718399457e06be"},
-    {file = "pydantic_core-2.18.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:97736815b9cc893b2b7f663628e63f436018b75f44854c8027040e05230eeddb"},
-    {file = "pydantic_core-2.18.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:6891a2ae0e8692679c07728819b6e2b822fb30ca7445f67bbf6509b25a96332c"},
-    {file = "pydantic_core-2.18.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bc4ff9805858bd54d1a20efff925ccd89c9d2e7cf4986144b30802bf78091c3e"},
-    {file = "pydantic_core-2.18.4-cp310-none-win32.whl", hash = "sha256:1b4de2e51bbcb61fdebd0ab86ef28062704f62c82bbf4addc4e37fa4b00b7cbc"},
-    {file = "pydantic_core-2.18.4-cp310-none-win_amd64.whl", hash = "sha256:6a750aec7bf431517a9fd78cb93c97b9b0c496090fee84a47a0d23668976b4b0"},
-    {file = "pydantic_core-2.18.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:942ba11e7dfb66dc70f9ae66b33452f51ac7bb90676da39a7345e99ffb55402d"},
-    {file = "pydantic_core-2.18.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b2ebef0e0b4454320274f5e83a41844c63438fdc874ea40a8b5b4ecb7693f1c4"},
-    {file = "pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a642295cd0c8df1b86fc3dced1d067874c353a188dc8e0f744626d49e9aa51c4"},
-    {file = "pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f09baa656c904807e832cf9cce799c6460c450c4ad80803517032da0cd062e2"},
-    {file = "pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:98906207f29bc2c459ff64fa007afd10a8c8ac080f7e4d5beff4c97086a3dabd"},
-    {file = "pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:19894b95aacfa98e7cb093cd7881a0c76f55731efad31073db4521e2b6ff5b7d"},
-    {file = "pydantic_core-2.18.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fbbdc827fe5e42e4d196c746b890b3d72876bdbf160b0eafe9f0334525119c8"},
-    {file = "pydantic_core-2.18.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f85d05aa0918283cf29a30b547b4df2fbb56b45b135f9e35b6807cb28bc47951"},
-    {file = "pydantic_core-2.18.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e85637bc8fe81ddb73fda9e56bab24560bdddfa98aa64f87aaa4e4b6730c23d2"},
-    {file = "pydantic_core-2.18.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2f5966897e5461f818e136b8451d0551a2e77259eb0f73a837027b47dc95dab9"},
-    {file = "pydantic_core-2.18.4-cp311-none-win32.whl", hash = "sha256:44c7486a4228413c317952e9d89598bcdfb06399735e49e0f8df643e1ccd0558"},
-    {file = "pydantic_core-2.18.4-cp311-none-win_amd64.whl", hash = "sha256:8a7164fe2005d03c64fd3b85649891cd4953a8de53107940bf272500ba8a788b"},
-    {file = "pydantic_core-2.18.4-cp311-none-win_arm64.whl", hash = "sha256:4e99bc050fe65c450344421017f98298a97cefc18c53bb2f7b3531eb39bc7805"},
-    {file = "pydantic_core-2.18.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6f5c4d41b2771c730ea1c34e458e781b18cc668d194958e0112455fff4e402b2"},
-    {file = "pydantic_core-2.18.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2fdf2156aa3d017fddf8aea5adfba9f777db1d6022d392b682d2a8329e087cef"},
-    {file = "pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4748321b5078216070b151d5271ef3e7cc905ab170bbfd27d5c83ee3ec436695"},
-    {file = "pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847a35c4d58721c5dc3dba599878ebbdfd96784f3fb8bb2c356e123bdcd73f34"},
-    {file = "pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c40d4eaad41f78e3bbda31b89edc46a3f3dc6e171bf0ecf097ff7a0ffff7cb1"},
-    {file = "pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:21a5e440dbe315ab9825fcd459b8814bb92b27c974cbc23c3e8baa2b76890077"},
-    {file = "pydantic_core-2.18.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01dd777215e2aa86dfd664daed5957704b769e726626393438f9c87690ce78c3"},
-    {file = "pydantic_core-2.18.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4b06beb3b3f1479d32befd1f3079cc47b34fa2da62457cdf6c963393340b56e9"},
-    {file = "pydantic_core-2.18.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:564d7922e4b13a16b98772441879fcdcbe82ff50daa622d681dd682175ea918c"},
-    {file = "pydantic_core-2.18.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0eb2a4f660fcd8e2b1c90ad566db2b98d7f3f4717c64fe0a83e0adb39766d5b8"},
-    {file = "pydantic_core-2.18.4-cp312-none-win32.whl", hash = "sha256:8b8bab4c97248095ae0c4455b5a1cd1cdd96e4e4769306ab19dda135ea4cdb07"},
-    {file = "pydantic_core-2.18.4-cp312-none-win_amd64.whl", hash = "sha256:14601cdb733d741b8958224030e2bfe21a4a881fb3dd6fbb21f071cabd48fa0a"},
-    {file = "pydantic_core-2.18.4-cp312-none-win_arm64.whl", hash = "sha256:c1322d7dd74713dcc157a2b7898a564ab091ca6c58302d5c7b4c07296e3fd00f"},
-    {file = "pydantic_core-2.18.4-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:823be1deb01793da05ecb0484d6c9e20baebb39bd42b5d72636ae9cf8350dbd2"},
-    {file = "pydantic_core-2.18.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ebef0dd9bf9b812bf75bda96743f2a6c5734a02092ae7f721c048d156d5fabae"},
-    {file = "pydantic_core-2.18.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae1d6df168efb88d7d522664693607b80b4080be6750c913eefb77e34c12c71a"},
-    {file = "pydantic_core-2.18.4-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f9899c94762343f2cc2fc64c13e7cae4c3cc65cdfc87dd810a31654c9b7358cc"},
-    {file = "pydantic_core-2.18.4-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:99457f184ad90235cfe8461c4d70ab7dd2680e28821c29eca00252ba90308c78"},
-    {file = "pydantic_core-2.18.4-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:18f469a3d2a2fdafe99296a87e8a4c37748b5080a26b806a707f25a902c040a8"},
-    {file = "pydantic_core-2.18.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7cdf28938ac6b8b49ae5e92f2735056a7ba99c9b110a474473fd71185c1af5d"},
-    {file = "pydantic_core-2.18.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:938cb21650855054dc54dfd9120a851c974f95450f00683399006aa6e8abb057"},
-    {file = "pydantic_core-2.18.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:44cd83ab6a51da80fb5adbd9560e26018e2ac7826f9626bc06ca3dc074cd198b"},
-    {file = "pydantic_core-2.18.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:972658f4a72d02b8abfa2581d92d59f59897d2e9f7e708fdabe922f9087773af"},
-    {file = "pydantic_core-2.18.4-cp38-none-win32.whl", hash = "sha256:1d886dc848e60cb7666f771e406acae54ab279b9f1e4143babc9c2258213daa2"},
-    {file = "pydantic_core-2.18.4-cp38-none-win_amd64.whl", hash = "sha256:bb4462bd43c2460774914b8525f79b00f8f407c945d50881568f294c1d9b4443"},
-    {file = "pydantic_core-2.18.4-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:44a688331d4a4e2129140a8118479443bd6f1905231138971372fcde37e43528"},
-    {file = "pydantic_core-2.18.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a2fdd81edd64342c85ac7cf2753ccae0b79bf2dfa063785503cb85a7d3593223"},
-    {file = "pydantic_core-2.18.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86110d7e1907ab36691f80b33eb2da87d780f4739ae773e5fc83fb272f88825f"},
-    {file = "pydantic_core-2.18.4-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46387e38bd641b3ee5ce247563b60c5ca098da9c56c75c157a05eaa0933ed154"},
-    {file = "pydantic_core-2.18.4-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:123c3cec203e3f5ac7b000bd82235f1a3eced8665b63d18be751f115588fea30"},
-    {file = "pydantic_core-2.18.4-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dc1803ac5c32ec324c5261c7209e8f8ce88e83254c4e1aebdc8b0a39f9ddb443"},
-    {file = "pydantic_core-2.18.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53db086f9f6ab2b4061958d9c276d1dbe3690e8dd727d6abf2321d6cce37fa94"},
-    {file = "pydantic_core-2.18.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abc267fa9837245cc28ea6929f19fa335f3dc330a35d2e45509b6566dc18be23"},
-    {file = "pydantic_core-2.18.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:a0d829524aaefdebccb869eed855e2d04c21d2d7479b6cada7ace5448416597b"},
-    {file = "pydantic_core-2.18.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:509daade3b8649f80d4e5ff21aa5673e4ebe58590b25fe42fac5f0f52c6f034a"},
-    {file = "pydantic_core-2.18.4-cp39-none-win32.whl", hash = "sha256:ca26a1e73c48cfc54c4a76ff78df3727b9d9f4ccc8dbee4ae3f73306a591676d"},
-    {file = "pydantic_core-2.18.4-cp39-none-win_amd64.whl", hash = "sha256:c67598100338d5d985db1b3d21f3619ef392e185e71b8d52bceacc4a7771ea7e"},
-    {file = "pydantic_core-2.18.4-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:574d92eac874f7f4db0ca653514d823a0d22e2354359d0759e3f6a406db5d55d"},
-    {file = "pydantic_core-2.18.4-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1f4d26ceb5eb9eed4af91bebeae4b06c3fb28966ca3a8fb765208cf6b51102ab"},
-    {file = "pydantic_core-2.18.4-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77450e6d20016ec41f43ca4a6c63e9fdde03f0ae3fe90e7c27bdbeaece8b1ed4"},
-    {file = "pydantic_core-2.18.4-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d323a01da91851a4f17bf592faf46149c9169d68430b3146dcba2bb5e5719abc"},
-    {file = "pydantic_core-2.18.4-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:43d447dd2ae072a0065389092a231283f62d960030ecd27565672bd40746c507"},
-    {file = "pydantic_core-2.18.4-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:578e24f761f3b425834f297b9935e1ce2e30f51400964ce4801002435a1b41ef"},
-    {file = "pydantic_core-2.18.4-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:81b5efb2f126454586d0f40c4d834010979cb80785173d1586df845a632e4e6d"},
-    {file = "pydantic_core-2.18.4-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ab86ce7c8f9bea87b9d12c7f0af71102acbf5ecbc66c17796cff45dae54ef9a5"},
-    {file = "pydantic_core-2.18.4-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:90afc12421df2b1b4dcc975f814e21bc1754640d502a2fbcc6d41e77af5ec312"},
-    {file = "pydantic_core-2.18.4-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:51991a89639a912c17bef4b45c87bd83593aee0437d8102556af4885811d59f5"},
-    {file = "pydantic_core-2.18.4-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:293afe532740370aba8c060882f7d26cfd00c94cae32fd2e212a3a6e3b7bc15e"},
-    {file = "pydantic_core-2.18.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b48ece5bde2e768197a2d0f6e925f9d7e3e826f0ad2271120f8144a9db18d5c8"},
-    {file = "pydantic_core-2.18.4-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eae237477a873ab46e8dd748e515c72c0c804fb380fbe6c85533c7de51f23a8f"},
-    {file = "pydantic_core-2.18.4-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:834b5230b5dfc0c1ec37b2fda433b271cbbc0e507560b5d1588e2cc1148cf1ce"},
-    {file = "pydantic_core-2.18.4-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e858ac0a25074ba4bce653f9b5d0a85b7456eaddadc0ce82d3878c22489fa4ee"},
-    {file = "pydantic_core-2.18.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2fd41f6eff4c20778d717af1cc50eca52f5afe7805ee530a4fbd0bae284f16e9"},
-    {file = "pydantic_core-2.18.4.tar.gz", hash = "sha256:ec3beeada09ff865c344ff3bc2f427f5e6c26401cc6113d77e372c3fdac73864"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3acae97ffd19bf091c72df4d726d552c473f3576409b2a7ca36b2f535ffff4a3"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41f4c96227a67a013e7de5ff8f20fb496ce573893b7f4f2707d065907bffdbd6"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f239eb799a2081495ea659d8d4a43a8f42cd1fe9ff2e7e436295c38a10c286a"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53e431da3fc53360db73eedf6f7124d1076e1b4ee4276b36fb25514544ceb4a3"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1f62b2413c3a0e846c3b838b2ecd6c7a19ec6793b2a522745b0869e37ab5bc1"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d41e6daee2813ecceea8eda38062d69e280b39df793f5a942fa515b8ed67953"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d482efec8b7dc6bfaedc0f166b2ce349df0011f5d2f1f25537ced4cfc34fd98"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e93e1a4b4b33daed65d781a57a522ff153dcf748dee70b40c7258c5861e1768a"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e7c4ea22b6739b162c9ecaaa41d718dfad48a244909fe7ef4b54c0b530effc5a"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4f2790949cf385d985a31984907fecb3896999329103df4e4983a4a41e13e840"},
+    {file = "pydantic_core-2.20.1-cp310-none-win32.whl", hash = "sha256:5e999ba8dd90e93d57410c5e67ebb67ffcaadcea0ad973240fdfd3a135506250"},
+    {file = "pydantic_core-2.20.1-cp310-none-win_amd64.whl", hash = "sha256:512ecfbefef6dac7bc5eaaf46177b2de58cdf7acac8793fe033b24ece0b9566c"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d2a8fa9d6d6f891f3deec72f5cc668e6f66b188ab14bb1ab52422fe8e644f312"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:175873691124f3d0da55aeea1d90660a6ea7a3cfea137c38afa0a5ffabe37b88"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37eee5b638f0e0dcd18d21f59b679686bbd18917b87db0193ae36f9c23c355fc"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25e9185e2d06c16ee438ed39bf62935ec436474a6ac4f9358524220f1b236e43"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:150906b40ff188a3260cbee25380e7494ee85048584998c1e66df0c7a11c17a6"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ad4aeb3e9a97286573c03df758fc7627aecdd02f1da04516a86dc159bf70121"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3f3ed29cd9f978c604708511a1f9c2fdcb6c38b9aae36a51905b8811ee5cbf1"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0dae11d8f5ded51699c74d9548dcc5938e0804cc8298ec0aa0da95c21fff57b"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:faa6b09ee09433b87992fb5a2859efd1c264ddc37280d2dd5db502126d0e7f27"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9dc1b507c12eb0481d071f3c1808f0529ad41dc415d0ca11f7ebfc666e66a18b"},
+    {file = "pydantic_core-2.20.1-cp311-none-win32.whl", hash = "sha256:fa2fddcb7107e0d1808086ca306dcade7df60a13a6c347a7acf1ec139aa6789a"},
+    {file = "pydantic_core-2.20.1-cp311-none-win_amd64.whl", hash = "sha256:40a783fb7ee353c50bd3853e626f15677ea527ae556429453685ae32280c19c2"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:595ba5be69b35777474fa07f80fc260ea71255656191adb22a8c53aba4479231"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a4f55095ad087474999ee28d3398bae183a66be4823f753cd7d67dd0153427c9"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9aa05d09ecf4c75157197f27cdc9cfaeb7c5f15021c6373932bf3e124af029f"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e97fdf088d4b31ff4ba35db26d9cc472ac7ef4a2ff2badeabf8d727b3377fc52"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bc633a9fe1eb87e250b5c57d389cf28998e4292336926b0b6cdaee353f89a237"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d573faf8eb7e6b1cbbcb4f5b247c60ca8be39fe2c674495df0eb4318303137fe"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26dc97754b57d2fd00ac2b24dfa341abffc380b823211994c4efac7f13b9e90e"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:33499e85e739a4b60c9dac710c20a08dc73cb3240c9a0e22325e671b27b70d24"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bebb4d6715c814597f85297c332297c6ce81e29436125ca59d1159b07f423eb1"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:516d9227919612425c8ef1c9b869bbbee249bc91912c8aaffb66116c0b447ebd"},
+    {file = "pydantic_core-2.20.1-cp312-none-win32.whl", hash = "sha256:469f29f9093c9d834432034d33f5fe45699e664f12a13bf38c04967ce233d688"},
+    {file = "pydantic_core-2.20.1-cp312-none-win_amd64.whl", hash = "sha256:035ede2e16da7281041f0e626459bcae33ed998cca6a0a007a5ebb73414ac72d"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0827505a5c87e8aa285dc31e9ec7f4a17c81a813d45f70b1d9164e03a813a686"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19c0fa39fa154e7e0b7f82f88ef85faa2a4c23cc65aae2f5aea625e3c13c735a"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa223cd1e36b642092c326d694d8bf59b71ddddc94cdb752bbbb1c5c91d833b"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c336a6d235522a62fef872c6295a42ecb0c4e1d0f1a3e500fe949415761b8a19"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7eb6a0587eded33aeefea9f916899d42b1799b7b14b8f8ff2753c0ac1741edac"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:70c8daf4faca8da5a6d655f9af86faf6ec2e1768f4b8b9d0226c02f3d6209703"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9fa4c9bf273ca41f940bceb86922a7667cd5bf90e95dbb157cbb8441008482c"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:11b71d67b4725e7e2a9f6e9c0ac1239bbc0c48cce3dc59f98635efc57d6dac83"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:270755f15174fb983890c49881e93f8f1b80f0b5e3a3cc1394a255706cabd203"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:c81131869240e3e568916ef4c307f8b99583efaa60a8112ef27a366eefba8ef0"},
+    {file = "pydantic_core-2.20.1-cp313-none-win32.whl", hash = "sha256:b91ced227c41aa29c672814f50dbb05ec93536abf8f43cd14ec9521ea09afe4e"},
+    {file = "pydantic_core-2.20.1-cp313-none-win_amd64.whl", hash = "sha256:65db0f2eefcaad1a3950f498aabb4875c8890438bc80b19362cf633b87a8ab20"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:4745f4ac52cc6686390c40eaa01d48b18997cb130833154801a442323cc78f91"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a8ad4c766d3f33ba8fd692f9aa297c9058970530a32c728a2c4bfd2616d3358b"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41e81317dd6a0127cabce83c0c9c3fbecceae981c8391e6f1dec88a77c8a569a"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04024d270cf63f586ad41fff13fde4311c4fc13ea74676962c876d9577bcc78f"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eaad4ff2de1c3823fddf82f41121bdf453d922e9a238642b1dedb33c4e4f98ad"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26ab812fa0c845df815e506be30337e2df27e88399b985d0bb4e3ecfe72df31c"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c5ebac750d9d5f2706654c638c041635c385596caf68f81342011ddfa1e5598"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2aafc5a503855ea5885559eae883978c9b6d8c8993d67766ee73d82e841300dd"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4868f6bd7c9d98904b748a2653031fc9c2f85b6237009d475b1008bfaeb0a5aa"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:aa2f457b4af386254372dfa78a2eda2563680d982422641a85f271c859df1987"},
+    {file = "pydantic_core-2.20.1-cp38-none-win32.whl", hash = "sha256:225b67a1f6d602de0ce7f6c1c3ae89a4aa25d3de9be857999e9124f15dab486a"},
+    {file = "pydantic_core-2.20.1-cp38-none-win_amd64.whl", hash = "sha256:6b507132dcfc0dea440cce23ee2182c0ce7aba7054576efc65634f080dbe9434"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:b03f7941783b4c4a26051846dea594628b38f6940a2fdc0df00b221aed39314c"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1eedfeb6089ed3fad42e81a67755846ad4dcc14d73698c120a82e4ccf0f1f9f6"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:635fee4e041ab9c479e31edda27fcf966ea9614fff1317e280d99eb3e5ab6fe2"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:77bf3ac639c1ff567ae3b47f8d4cc3dc20f9966a2a6dd2311dcc055d3d04fb8a"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ed1b0132f24beeec5a78b67d9388656d03e6a7c837394f99257e2d55b461611"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6514f963b023aeee506678a1cf821fe31159b925c4b76fe2afa94cc70b3222b"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10d4204d8ca33146e761c79f83cc861df20e7ae9f6487ca290a97702daf56006"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2d036c7187b9422ae5b262badb87a20a49eb6c5238b2004e96d4da1231badef1"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9ebfef07dbe1d93efb94b4700f2d278494e9162565a54f124c404a5656d7ff09"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6b9d9bb600328a1ce523ab4f454859e9d439150abb0906c5a1983c146580ebab"},
+    {file = "pydantic_core-2.20.1-cp39-none-win32.whl", hash = "sha256:784c1214cb6dd1e3b15dd8b91b9a53852aed16671cc3fbe4786f4f1db07089e2"},
+    {file = "pydantic_core-2.20.1-cp39-none-win_amd64.whl", hash = "sha256:d2fe69c5434391727efa54b47a1e7986bb0186e72a41b203df8f5b0a19a4f669"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:a45f84b09ac9c3d35dfcf6a27fd0634d30d183205230a0ebe8373a0e8cfa0906"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d02a72df14dfdbaf228424573a07af10637bd490f0901cee872c4f434a735b94"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2b27e6af28f07e2f195552b37d7d66b150adbaa39a6d327766ffd695799780f"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:084659fac3c83fd674596612aeff6041a18402f1e1bc19ca39e417d554468482"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:242b8feb3c493ab78be289c034a1f659e8826e2233786e36f2893a950a719bb6"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:38cf1c40a921d05c5edc61a785c0ddb4bed67827069f535d794ce6bcded919fc"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e0bbdd76ce9aa5d4209d65f2b27fc6e5ef1312ae6c5333c26db3f5ade53a1e99"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:254ec27fdb5b1ee60684f91683be95e5133c994cc54e86a0b0963afa25c8f8a6"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:407653af5617f0757261ae249d3fba09504d7a71ab36ac057c938572d1bc9331"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:c693e916709c2465b02ca0ad7b387c4f8423d1db7b4649c551f27a529181c5ad"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b5ff4911aea936a47d9376fd3ab17e970cc543d1b68921886e7f64bd28308d1"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:177f55a886d74f1808763976ac4efd29b7ed15c69f4d838bbd74d9d09cf6fa86"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:964faa8a861d2664f0c7ab0c181af0bea66098b1919439815ca8803ef136fc4e"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:4dd484681c15e6b9a977c785a345d3e378d72678fd5f1f3c0509608da24f2ac0"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f6d6cff3538391e8486a431569b77921adfcdef14eb18fbf19b7c0a5294d4e6a"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a6d511cc297ff0883bc3708b465ff82d7560193169a8b93260f74ecb0a5e08a7"},
+    {file = "pydantic_core-2.20.1.tar.gz", hash = "sha256:26ca695eeee5f9f1aeeb211ffc12f10bcb6f71e2989988fda61dabd65db878d4"},
 ]
 
 [package.dependencies]
@@ -2614,8 +2627,8 @@ files = [
 
 [package.dependencies]
 astroid = [
-    {version = ">=2.7", markers = "python_version < \"3.12\""},
     {version = ">=3.0.0a1", markers = "python_version >= \"3.12\""},
+    {version = ">=2.7", markers = "python_version < \"3.12\""},
 ]
 Jinja2 = "*"
 PyYAML = "*"
@@ -2842,6 +2855,17 @@ python-versions = ">=3.8"
 files = [
     {file = "typing_extensions-4.12.1-py3-none-any.whl", hash = "sha256:6024b58b69089e5a89c347397254e35f1bf02a907728ec7fee9bf0fe837d203a"},
     {file = "typing_extensions-4.12.1.tar.gz", hash = "sha256:915f5e35ff76f56588223f15fdd5938f9a1cf9195c0de25130c627e4d597f6d1"},
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+description = "Backported and Experimental Type Hints for Python 3.8+"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
+    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]
@@ -3087,4 +3111,4 @@ jupyter = ["ipytree (>=0.2.2)", "ipywidgets (>=8.0.0)", "notebook"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "74ac909f028646dda1c0893ac46345b23ef3f2cb5e2e90a3f313a2661ee41b73"
+content-hash = "18d9f01b8c1bc954bdcfe2c5a086f716c573f3fed36611e9aca2ac9580a3a6c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,16 @@ readme = "README.md"
 packages = [{ include = "modos" }]
 
 [tool.poetry.dependencies]
-python = "^3.10"
-rdflib = "^6.3"
-zarr = "^2.16.1"
 calamus = "^0.4.2"
-pysam = "^0.22.0"
 modos_schema = "0.1.0"
-typer = "^0.9.0"
-s3fs = "^2024.3.1"
+pysam = "^0.22.0"
+python = "^3.10"
 pyyaml = "^6.0.1"
+rdflib = "^6.3"
+s3fs = "^2024.3.1"
+typer = "^0.9.0"
+zarr = "^2.16.1"
+pydantic = "^2.8.2"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.6.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,6 @@ def remote_modo(setup):
     minio_creds = {"secret": "minioadmin", "key": "minioadmin"}
     return MODO(
         "test/ex",
-        s3_endpoint=f"http://{minio_endpoint}",
+        _s3_endpoint=f"http://{minio_endpoint}",
         s3_kwargs=minio_creds,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ def remote_modo(setup):
     minio_endpoint = setup["minio"].get_config()["endpoint"]
     minio_creds = {"secret": "minioadmin", "key": "minioadmin"}
     return MODO(
-        "test/ex",
+        "s3://test/ex",
         services={"s3": f"http://{minio_endpoint}"},
         s3_kwargs=minio_creds,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,6 @@ def remote_modo(setup):
     minio_creds = {"secret": "minioadmin", "key": "minioadmin"}
     return MODO(
         "test/ex",
-        _s3_endpoint=f"http://{minio_endpoint}",
+        services={"s3": f"http://{minio_endpoint}"},
         s3_kwargs=minio_creds,
     )

--- a/tests/test_api_remote.py
+++ b/tests/test_api_remote.py
@@ -15,7 +15,7 @@ def test_multi_modos(setup):
     minio_creds = {"secret": "minioadmin", "key": "minioadmin"}
     for _ in range(3):
         MODO(
-            "test/ex",
+            "s3://test/ex",
             services={"s3": f"http://{minio_endpoint}"},
             s3_kwargs=minio_creds,
         )
@@ -59,7 +59,7 @@ def test_remove_modo(setup):
     minio_endpoint = setup["minio"].get_config()["endpoint"]
     minio_creds = {"secret": "minioadmin", "key": "minioadmin"}
     modo = MODO(
-        "test/remove_ex",
+        "s3://test/remove_ex",
         services={"s3": f"http://{minio_endpoint}"},
         s3_kwargs=minio_creds,
     )

--- a/tests/test_api_remote.py
+++ b/tests/test_api_remote.py
@@ -16,7 +16,7 @@ def test_multi_modos(setup):
     for _ in range(3):
         MODO(
             "test/ex",
-            s3_endpoint=f"http://{minio_endpoint}",
+            _s3_endpoint=f"http://{minio_endpoint}",
             s3_kwargs=minio_creds,
         )
 
@@ -60,7 +60,7 @@ def test_remove_modo(setup):
     minio_creds = {"secret": "minioadmin", "key": "minioadmin"}
     modo = MODO(
         "test/remove_ex",
-        s3_endpoint=f"http://{minio_endpoint}",
+        _s3_endpoint=f"http://{minio_endpoint}",
         s3_kwargs=minio_creds,
     )
     objects = minio_client.list_objects("test")

--- a/tests/test_api_remote.py
+++ b/tests/test_api_remote.py
@@ -16,7 +16,7 @@ def test_multi_modos(setup):
     for _ in range(3):
         MODO(
             "test/ex",
-            _s3_endpoint=f"http://{minio_endpoint}",
+            services={"s3": f"http://{minio_endpoint}"},
             s3_kwargs=minio_creds,
         )
 
@@ -60,7 +60,7 @@ def test_remove_modo(setup):
     minio_creds = {"secret": "minioadmin", "key": "minioadmin"}
     modo = MODO(
         "test/remove_ex",
-        _s3_endpoint=f"http://{minio_endpoint}",
+        services={"s3": f"http://{minio_endpoint}"},
         s3_kwargs=minio_creds,
     )
     objects = minio_client.list_objects("test")


### PR DESCRIPTION
**Objective:**

Allows users to always specify the same modos server endpoint. Underlying htsget/s3 endpoints are auto-detected internally by querying the modos server.

For testing / advanced usage, a `services` option is still exposed in the API to bypass this and explicitely provide service endpoints.

**Notes**

* As every command in the CLI was copy-pasting the `s3_endpoint` option, this PR removes it in favor of a top-level `endpoint` flag that is inherited by all commands (through typer.Context).
* `endpoint` option can also read from the environment variable `MODOS_ENDPOINT`.
* the docker compose config used a static network ip. This was only needed because we passed the S3_LOCAL_URL to htsget instead of S3_PUBLIC_URL (by mistake). Fixing the env var makes the static IP unnecessary, and this PR removes it.
* `pydantic.HttpUrl` was used in some places for more explicit type hints, this PR adds it throughout the package and decorates functions with `@validate_call`, to validate url params at runtime.
* expose the version from `pyproject.toml` through `modos.__version__` and in the cli through `modos --version` using a typer callback.
* describe MODO arguments in docstring

**Limitations**

* If the environment variable is set, the user has to manually override it to create local objects which may not be intuitive.
* This PR implements runtime parameter validation on functions (via `pydantic.validate_call`) and dataclases (by replacing `dataclasses.dataclass` with `pydantic.dataclasses.dataclass`), but not on normal classes.

**Questions**
should we use a more explicit mechanism for remote/local paths to avoid confusion? (e.g. `--local` flag or explicitely requiring `s3://` paths for remote objects.). Should this be in this, or a separate PR?


**Examples**

CLI:
```shell
$ modos --version
modos 0.1.0

# create remote object on the s3 provided by the modos server at http://localhost
$ modos --endpoint http://localhost create bucket/object

# read endpoint from env variable to avoid repetition
$ export MODOS_ENDPOINT='http://localhost'
$ modos create bucket/object2
$ modos show bucket/object2
$ modos delete bucket/object2
```

API:
```python
>>> from modos.api import MODO
>>> MODO('bucket/object2', endpoint='http://localhost')

# This is also possible, e.g. user has an s3 server, but no modos server
>>> nostream = MODO('bucket/ex-nostream', services={'s3': 'http://s3.example.org'})
>>> nostream.stream_genomics('demo1.cram')
ValueError: No htsget endpoint provided
```