### PR TITLE
ci: build and publish at pypi/test-pypi

### DIFF
--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -59,4 +59,4 @@ jobs:
         path: dist/
     - name: Publish package distributions to PyPI
     # https://github.com/pypa/gh-action-pypi-publish
-      uses: pypa/gh-action-pypi-publish@release/v1.9.0
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
 
 jobs:
+  run-tests:
+    uses: ./.github/workflows/poetry-publish.yml
+
   release-build:
     name: Build python wheels
     runs-on: ubuntu-latest

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -1,0 +1,19 @@
+name: Publish on Pypi
+
+on:
+  release:
+    types: [published]
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+      # https://github.com/JRubics/poetry-publish
+      - name: Build and publish to pypi
+        uses: JRubics/poetry-publish@v2.0
+        with:
+          pypi_token: ${{ secrets.PYPI_API_TOKEN }}
+          poetry_install_options: "--only-root"

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -23,7 +23,7 @@ jobs:
       # https://github.com/actions/setup-python
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install Poetry
         run: |

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -1,19 +1,62 @@
-name: Publish on Pypi
+# Workflow following resources at:
+#  - https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-pypi
+#  - https://packaging.python.org/en/latest/tutorials/packaging-projects/#uploading-the-distribution-archives
+# Jobs are split to prevent unneccessary priviledge elevation through write permissions during building.
+
+name: Build and publish on Pypi
 
 on:
   release:
     types: [published]
-    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
-  build:
+  release-build:
+    name: Build python wheels
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout
       - uses: actions/checkout@v4
-      # https://github.com/JRubics/poetry-publish
-      - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v2.0
+      - name: Set up Python
+      # https://github.com/actions/setup-python
+        uses: actions/setup-python@v5.1.1
         with:
-          pypi_token: ${{ secrets.PYPI_API_TOKEN }}
-          poetry_install_options: "--only-root"
+          python-version: 3.10
+
+      - name: Install Poetry
+        run: |
+          pip install poetry
+
+      - name: Build source and wheel archives
+        run: poetry build
+
+      - name: Upload distributions
+      # https://github.com/actions/upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish:
+    name: Upload release to PyPI
+    needs:
+      - release-build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/modos
+    permissions:
+      id-token: write
+      # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - name: Retrieve release distributions
+    # https://github.com/actions/download-artifact
+      uses: actions/download-artifact@v4.1.8
+      with:
+        name: release-dists
+        path: dist/
+    - name: Publish package distributions to PyPI
+    # https://github.com/pypa/gh-action-pypi-publish
+      uses: pypa/gh-action-pypi-publish@release/v1.9.1

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -18,6 +18,8 @@ jobs:
 
   release-build:
     name: Build python wheels
+    needs:
+      - run-tests
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -59,4 +59,4 @@ jobs:
         path: dist/
     - name: Publish package distributions to PyPI
     # https://github.com/pypa/gh-action-pypi-publish
-      uses: pypa/gh-action-pypi-publish@release/v1.9.1
+      uses: pypa/gh-action-pypi-publish@release/v1.9.0

--- a/.github/workflows/poetry-publish.yml
+++ b/.github/workflows/poetry-publish.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   run-tests:
-    uses: ./.github/workflows/poetry-publish.yml
+    uses: ./.github/workflows/poetry-pytest.yml
 
   release-build:
     name: Build python wheels

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -1,8 +1,6 @@
 name: tests
 
-on:
-  push:
-  workflow_call:
+on: [push, workflow_call]
 
 jobs:
 

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -1,6 +1,8 @@
 name: tests
 
-on: [push]
+on:
+  push:
+  workflow_call:
 
 jobs:
 

--- a/.github/workflows/poetry-test-publish.yml
+++ b/.github/workflows/poetry-test-publish.yml
@@ -58,6 +58,6 @@ jobs:
         path: dist/
     - name: Publish package distributions to TestPyPI
     # https://github.com/pypa/gh-action-pypi-publish
-      uses: pypa/gh-action-pypi-publish@release/v1.9.0
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/poetry-test-publish.yml
+++ b/.github/workflows/poetry-test-publish.yml
@@ -58,6 +58,6 @@ jobs:
         path: dist/
     - name: Publish package distributions to TestPyPI
     # https://github.com/pypa/gh-action-pypi-publish
-      uses: pypa/gh-action-pypi-publish@release/v1.9.1
+      uses: pypa/gh-action-pypi-publish@release/v1.9.0
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/poetry-test-publish.yml
+++ b/.github/workflows/poetry-test-publish.yml
@@ -7,6 +7,8 @@ name: Build and publish on Pypi Test
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ci/poetry-publish]
 
 permissions:
   contents: read

--- a/.github/workflows/poetry-test-publish.yml
+++ b/.github/workflows/poetry-test-publish.yml
@@ -16,6 +16,8 @@ jobs:
     uses: ./.github/workflows/poetry-pytest.yml
   test-build:
     name: Build python wheels
+    needs:
+      - run-tests
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout

--- a/.github/workflows/poetry-test-publish.yml
+++ b/.github/workflows/poetry-test-publish.yml
@@ -1,19 +1,63 @@
-name: Publish on Pypi Test
+# Workflow following resources at:
+#  - https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-pypi
+#  - https://packaging.python.org/en/latest/tutorials/packaging-projects/#uploading-the-distribution-archives
+# Jobs are split to prevent unneccessary priviledge elevation through write permissions during building.
+
+name: Build and publish on Pypi Test
 
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
-  build:
+  test-build:
+    name: Build python wheels
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/checkout
       - uses: actions/checkout@v4
-      - name: Build and publish to pypi
-      # https://github.com/JRubics/poetry-publish
-        uses: JRubics/poetry-publish@v2.0
+      - name: Set up Python
+      # https://github.com/actions/setup-python
+        uses: actions/setup-python@v5.1.1
         with:
-          pypi_token: ${{ secrets.PYPI_TEST_API_TOKEN }}
-          repository_name: "testpypi"
-          repository_url: "https://test.pypi.org/legacy/"
-          poetry_install_options: "--only-root"
+          python-version: 3.10
+
+      - name: Install Poetry
+        run: |
+          pip install poetry
+
+      - name: Build source and wheel archives
+        run: poetry build
+
+      - name: Upload distributions
+      # https://github.com/actions/upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-dists
+          path: dist/
+
+  pypi-test-publish:
+    name: Upload release to PyPI Test
+    needs:
+      - test-build
+    runs-on: ubuntu-latest
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/p/modos
+    permissions:
+      id-token: write
+      # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - name: Retrieve release distributions
+    # https://github.com/actions/download-artifact
+      uses: actions/download-artifact@v4.1.8
+      with:
+        name: test-dists
+        path: dist/
+    - name: Publish package distributions to TestPyPI
+    # https://github.com/pypa/gh-action-pypi-publish
+      uses: pypa/gh-action-pypi-publish@release/v1.9.1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/poetry-test-publish.yml
+++ b/.github/workflows/poetry-test-publish.yml
@@ -12,6 +12,8 @@ permissions:
   contents: read
 
 jobs:
+  run-tests:
+    uses: ./.github/workflows/poetry-publish.yml
   test-build:
     name: Build python wheels
     runs-on: ubuntu-latest

--- a/.github/workflows/poetry-test-publish.yml
+++ b/.github/workflows/poetry-test-publish.yml
@@ -1,0 +1,19 @@
+name: Publish on Pypi Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+      - name: Build and publish to pypi
+      # https://github.com/JRubics/poetry-publish
+        uses: JRubics/poetry-publish@v2.0
+        with:
+          pypi_token: ${{ secrets.PYPI_TEST_API_TOKEN }}
+          repository_name: "testpypi"
+          repository_url: "https://test.pypi.org/legacy/"
+          poetry_install_options: "--only-root"

--- a/.github/workflows/poetry-test-publish.yml
+++ b/.github/workflows/poetry-test-publish.yml
@@ -7,8 +7,6 @@ name: Build and publish on Pypi Test
 
 on:
   workflow_dispatch:
-  push:
-    branches: [ci/poetry-publish]
 
 permissions:
   contents: read
@@ -24,7 +22,7 @@ jobs:
       # https://github.com/actions/setup-python
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Install Poetry
         run: |

--- a/.github/workflows/poetry-test-publish.yml
+++ b/.github/workflows/poetry-test-publish.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   run-tests:
-    uses: ./.github/workflows/poetry-publish.yml
+    uses: ./.github/workflows/poetry-pytest.yml
   test-build:
     name: Build python wheels
     runs-on: ubuntu-latest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = "modos-api"
 copyright = "2024, sdsc-ordes"
 author = "sdsc-ordes"
-release = "0.2.0"
+release = "0.2.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "modos"
-version = "0.2.0"
+version = "0.2.1"
 description = "SMOC Multi-Omics Digital Object System API"
 authors = ["SDSC-ORDES"]
 license = "Apache-2.0"


### PR DESCRIPTION
### Scope:
Two new github action workflows with 2 jobs each:
- `poetry-publish`: 1. build modos-api and 2. publish at pypi, triggered on published releases
- `poetry-test-publish`:  1. build modos-api and 2. publish at test-pypi, manually triggered by workflow dispatch

The publishing job uses trusted publisher management for authentication, which requires write permission. To not elevate privileges building and publishing were separated into two different ci-jobs as recommended.

### Limitations:
So far only `poetry-test-publish` was run (see [output](https://github.com/sdsc-ordes/modos-api/actions/runs/10265083314)) and tested. Both workflows are build analogous, but I think we have to wait for the next release to check `poetry-publish`? 
  