### PR TITLE
fix(rdf): schema.org prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ For advanced use cases, the object's metadata can be queried with SPARQL!
 >>> ex.query("""
 ...   SELECT ?assay ?sample ?file
 ...   WHERE {
-...     [] schema1:name ?assay ;
+...     [] schema:name ?assay ;
 ...       modos:has_data [
 ...         modos:data_path ?file ;
 ...         modos:has_sample [
-...           schema1:name ?sample ;
+...           schema:name ?sample ;
 ...           modos:sex ?sex .
 ...         ]
 ...       ] .

--- a/docs/tutorials/modo_access.md
+++ b/docs/tutorials/modo_access.md
@@ -120,12 +120,12 @@ modos publish --base-uri "http://demo-data" "data/ex"
 # @prefix EDAM: <http://edamontology.org/> .
 # @prefix NCIT: <http://purl.obolibrary.org/obo/NCIT_> .
 # @prefix modos: <https://w3id.org/sdsc-ordes/modos-schema/> .
-# @prefix schema1: <http://schema.org/> .
+# @prefix schema: <http://schema.org/> .
 # @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 #
 # <http://demo-data/assay/assay1> a modos:Assay ;
-#     schema1:description "Dummy assay for tests." ;
-#     schema1:name "Assay 1" ;
+#     schema:description "Dummy assay for tests." ;
+#     schema:name "Assay 1" ;
 #     modos:has_data <http://demo-data/demo1> ;
 #     modos:has_sample <http://demo-data/sample1> ;
 #     modos:omics_type NCIT:C84343 .

--- a/modos/rdf.py
+++ b/modos/rdf.py
@@ -16,7 +16,7 @@ def attrs_to_graph(meta: dict, uri_prefix: str) -> rdflib.Graph:
     """Convert a attribute dictionary to an RDF graph of metadata."""
     kg = rdflib.Graph()
     for prefix in load_prefixmap().values():
-        kg.bind(prefix.prefix_prefix, prefix.prefix_reference)
+        kg.bind(prefix.prefix_prefix, prefix.prefix_reference, replace=True)
 
     # Assuming the dict is flat, i.e. all subjects are top level
     for subject, attrs in meta.items():


### PR DESCRIPTION
The `schema` prefix is assigned by default by rdflib to **https**://schema.org.
Unfortunately, linkml cannot use **https**://schema.org and assigns the schema namespace to **http**://schema.org

As modos inherits **http** from linkml, all conversions to rdflib resulted in using the automatically assigned `schema1` prefix.

This PR overrides the default rdflib assignment of `schema` so that turtle serialization and SPARQL queries on modos objects can use the `schema` prefix.
