### PR TITLE
feat(cli, api):show only target element

### DIFF
--- a/modos/api.py
+++ b/modos/api.py
@@ -189,10 +189,10 @@ class MODO:
         """Lists files in the archive recursively (except for the zarr file)."""
         return [fi for fi in self.storage.list()]
 
-    def list_arrays(self):
+    def list_arrays(self, element_id: Optional[str] = None):
         """Lists arrays in the archive recursively."""
         root = zarr.convenience.open_consolidated(self.zarr.store)
-        return root.tree()
+        return root[element_id or "/"].tree()
 
     def query(self, query: str):
         """Use SPARQL to query the metadata graph"""

--- a/modos/api.py
+++ b/modos/api.py
@@ -176,9 +176,11 @@ class MODO:
         kg = attrs_to_graph(self.metadata, uri_prefix=uri_prefix)
         return kg
 
-    def show_contents(self):
+    def show_contents(self, element_id: Optional[str] = None):
         """human-readable print of the object's contents"""
         meta = self.metadata
+        if element_id:
+            meta = {element_id: meta[element_id]}
         # Pretty print metadata contents as yaml
 
         return yaml.dump(meta, sort_keys=False)

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -284,6 +284,13 @@ def add(
 def show(
     ctx: typer.Context,
     object_path: OBJECT_PATH_ARG,
+    element_id: Annotated[
+        Optional[str],
+        typer.Argument(
+            ...,
+            help="The identifier within the modo. Use modos show to check it.",
+        ),
+    ] = None,
     zarr: Annotated[
         bool,
         typer.Option(
@@ -310,11 +317,12 @@ def show(
     else:
         raise ValueError(f"{object_path} does not exists")
     if zarr:
-        out = obj.list_arrays()
+        out = obj.list_arrays(element_id)
     elif files:
         out = "\n".join([str(path) for path in obj.list_files()])
     else:
-        out = obj.show_contents()
+        out = obj.show_contents(element_id)
+
     print(out)
 
 


### PR DESCRIPTION
Quality of life feature to target a specific element when inspecting an object:

CLI:
```shell
$ modos show data/ex sample/sample1
sample/sample1:
  '@type': Sample
  cell_type: astrocyte
  description: Dummy sample for tests
  name: Sample 1
  sex: Male
  source_material: brain tissue

$ modos show --zarr data/ex assay
assay
 └── assay1
```

API:

```python
m = MODO('data/ex')
m.show_contents('sample/sample1')
m.list_arrays('data')
```

**Limitations**

Does not work with the `--files` option, as I was not sure whether it makes sense; e.g. should this list the index files (.crai, .csi, ...), should we list files directly linked to the element, or also recursively (sample1 -> data1 -> file).
