### PR TITLE
fix(rdf): inject schema:identifier

### DIFF
--- a/modos/helpers/schema.py
+++ b/modos/helpers/schema.py
@@ -257,6 +257,8 @@ def instance_to_graph(instance) -> Graph:
         prefix_map=prefixes,
         schemaview=load_schema(),
     )
+    # NOTE: This is a hack to get around the fact that the linkml's
+    # rdf dumper does not iunclude schema:identifier in the graph.
     # Patch schema -> http://schema.org (rdflib's default is https)
     g.bind("schema", "http://schema.org/", replace=True)
     try:

--- a/modos/helpers/schema.py
+++ b/modos/helpers/schema.py
@@ -252,11 +252,27 @@ def instance_to_graph(instance) -> Graph:
         p.prefix_prefix: URIRef(p.prefix_reference)
         for p in load_prefixmap().values()
     }
-    return rdflib_dumper.as_rdf_graph(
+    g = rdflib_dumper.as_rdf_graph(
         instance,
         prefix_map=prefixes,
         schemaview=load_schema(),
     )
+    # Patch schema -> http://schema.org (rdflib's default is https)
+    g.bind("schema", "http://schema.org/", replace=True)
+    try:
+        id_slot = (
+            load_schema().get_identifier_slot(type(instance).__name__).slot_uri
+        )
+        g.add(
+            (
+                URIRef(instance.id),
+                g.namespace_manager.expand_curie(str(id_slot)),
+                URIRef(instance.id),
+            )
+        )
+    except AttributeError:
+        pass
+    return g
 
 
 def get_slot_range(slot_name: str) -> str:


### PR DESCRIPTION
:warning: This is a workaround a linkml problem (or mis-use?), and I'm not sure it should be merged.

**Context**

`schema:identifier` is marked as mandatory in the schema, and appears as `minCount 1` in the modos-schema schacl rules, however when serializing our metadata graph to RDF, the resulting instances do not have any `schema:identifier` triple, meaning we are not compliant with the shapes.

**Proposed change**

This PR attempts to solve that by injecting the relevant triple into instance graphs upon serialization. The implementation is sort of convoluted and I wish there was a better way.


**Notes**

The identifier property is also not very useful as-is; a copy of the subject URI. In modos-schema, we require schema:identifier to be a URI, but I wonder if we should relax this requirement to be only locally unique (within MODO) and allow [identifiers](https://schema.org/identifier) to be string literals "type/id" (e.g. "sample/sample1"). This would require updating modos-schema. 

Perhaps this might be more useful in practice, at the cost of global uniqueness.

**Alternatives**

* Keep the code clean and remain non-shacl compliant.
* short string identifiers ("type/name") + edit schema

**Examples**

current (`main`) -> fails validation
```turtle
@prefix modos: <https://w3id.org/sdsc-ordes/modos-schema/> .
@prefix NCIT: <http://purl.obolibrary.org/obo/NCIT_> .
@prefix schema: <http://schema.org/> .

<file://ex/assay/assay1> a modos:Assay ;
    schema:description "Dummy assay for tests." ;
    schema:name "Assay 1" ;
    modos:has_data <file://ex/data/calls1>,
        <file://ex/data/demo1> ;
    modos:has_sample <file://ex/sample/sample1> ;
    modos:omics_type NCIT:C84343 .
```

this PR -> passes validation

```diff
    schema:description "Dummy assay for tests." ;
+   schema:identifier <file://ex/assay/assay1> ;
    schema:name "Assay 1" ;
```

short identifier -> passes validation (because range: uriorcurie was not translated into shacl):

```diff
    schema:description "Dummy assay for tests." ;
+   schema:identifier "assay/assay1" ;
    schema:name "Assay 1" ;
```
