### PR TITLE
fix(htsget): htsget minio connection

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     networks:
       - modos-network
     environment:
-      - ENDPOINT=${S3_PUBLIC_URL:-http://localhost/s3}
+      - ENDPOINT=${S3_LOCAL_URL:-http://minio:9000}
       - BUCKET=${S3_BUCKET:-modos-demo}
       - S3_ADDRESSING_STYLE=${S3_ADDRESSING_STYLE:-auto}
       - AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER:-minio}

--- a/deploy/htsget/docker-entrypoint.sh
+++ b/deploy/htsget/docker-entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e
 
-if [ "${S3_ADDRESSING_STYLE}" = "path" ]; then
-  export PATH_STYLE=true
-else
+if [ "${S3_ADDRESSING_STYLE}" = "virtual" ]; then
   export PATH_STYLE=false
+else
+  export PATH_STYLE=true
 fi
 
 # only use entrypoint if running htsget-actix

--- a/modos/genomics/htsget.py
+++ b/modos/genomics/htsget.py
@@ -74,8 +74,9 @@ def build_htsget_url(
     # remove .gz suffix if present
     stem = path.with_suffix("") if path.name.endswith("gz") else path
     stem = stem.with_suffix("")
+    netloc = host if str(host).endswith("/") else f"{host}/"
 
-    url = f"{host}{endpoint}/{stem}?format={format.name}"
+    url = f"{netloc}{endpoint}/{stem}?format={format.name}"
     if region:
         url += f"&{region.to_htsget_query()}"
     return url


### PR DESCRIPTION
This PR affects bugs that prevented htsget from connecting to the minio s3 bucket:
* fixed malformed URL when no trailing slash was present on the input enpoint
* Fixed compose environment variables to connect htsget to s3 using the service identifier unless S3_LOCAL_URL is set
* configure htsget to use path-style bucket by default