### PR TITLE
perf: use fuzon cache with CodeMatcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 ARG VERSION_BUILD
 
-FROM python:3.11-slim
 
-ENV PYTHONUNBUFFERED=true
-WORKDIR /app
 
 ##################################################
 # Poetry setup
 ##################################################
-FROM python AS poetry
+FROM python:3.12-slim AS poetry
 
 WORKDIR /app
 # Install poetry
+ENV PYTHONUNBUFFERED=true
 ENV POETRY_HOME=/opt/poetry
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 ENV PATH="$POETRY_HOME/bin:$PATH"
@@ -32,7 +30,7 @@ RUN poetry install --no-interaction --no-ansi -vvv
 ##################################################
 # modos setup
 ##################################################
-FROM python AS runtime
+FROM python:3.12-slim AS runtime
 ARG VERSION_BUILD
 ENV PATH="/app/.venv/bin:$PATH"
 COPY --from=poetry /app /app

--- a/modos/codes.py
+++ b/modos/codes.py
@@ -1,9 +1,9 @@
 """Utilities to automatically find / recommend terminology codes from text."""
 from dataclasses import dataclass
-import requests
 from typing import Optional, Protocol
 
-from requests.models import MissingSchema
+from pathlib import Path
+import requests
 
 
 SLOT_TERMINOLOGIES = {
@@ -49,6 +49,9 @@ class LocalCodeMatcher(CodeMatcher):
         try:
             self.matcher = cache.load_by_source(sources)
         except RuntimeError:
+            Path(cache.get_cache_path(sources)).parent.mkdir(
+                parents=True, exist_ok=True
+            )
             cache.cache_by_source(sources)
             self.matcher = cache.load_by_source(sources)
 

--- a/modos/codes.py
+++ b/modos/codes.py
@@ -3,11 +3,15 @@ from dataclasses import dataclass
 import requests
 from typing import Optional, Protocol
 
+from requests.models import MissingSchema
+
 
 SLOT_TERMINOLOGIES = {
-    "cell_type": "https://purl.obolibrary.org/obo/cl.owl",
-    "source_material": "https://purl.obolibrary.org/obo/uberon.owl",
-    "taxon_id": "https://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl",
+    "cell_type": ["https://purl.obolibrary.org/obo/cl.owl"],
+    "source_material": ["https://purl.obolibrary.org/obo/uberon.owl"],
+    "taxon_id": [
+        "https://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl"
+    ],
 }
 
 
@@ -35,14 +39,18 @@ class LocalCodeMatcher(CodeMatcher):
         self.top = top
 
         try:
-            from pyfuzon import TermMatcher
-
-            self.matcher = TermMatcher.from_files([SLOT_TERMINOLOGIES[slot]])
+            from pyfuzon import cache
         except ImportError:
-            raise ValueError(
-                """No endpoint provided and pyfuzon not installed,
-                cannot do code matching."""
+            raise ModuleNotFoundError(
+                "pyfuzon must be installed to perform local code matching."
             )
+
+        sources = SLOT_TERMINOLOGIES[slot]
+        try:
+            self.matcher = cache.load_by_source(sources)
+        except RuntimeError:
+            cache.cache_by_source(sources)
+            self.matcher = cache.load_by_source(sources)
 
     def find_codes(self, query: str) -> list[Code]:
         return self.matcher.top(query, self.top)


### PR DESCRIPTION
When using code search locally, loading the terminologies over the network can take up to 30s.

This PR implements caching so that this only happens the first time a terminology is used.
On subsequent loads, they are loaded from cache, which takes about 1s.

Caching logic is implemented in fuzon, and each terminology has one cache entry whose key is determined by its URL, last modified datetime and/or ETag checksum if available.