### PR TITLE
feat(cli): update prompts for removal of missing config elements

### DIFF
--- a/modos/api.py
+++ b/modos/api.py
@@ -555,7 +555,7 @@ class MODO:
                 modo.add_element(inst, **args)
         if no_remove:
             return modo
-        modo_id = modo_id = modo.zarr["/"].attrs["id"]
+        modo_id = modo.zarr["/"].attrs["id"]
         old_ids = [
             id for id in modo_ids.keys() if id not in ids and id != modo_id
         ]

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -22,7 +22,7 @@ from modos.codes import get_slot_matcher, SLOT_TERMINOLOGIES
 from modos.helpers.schema import UserElementType
 from modos.genomics.htsget import HtsgetConnection
 from modos.genomics.region import Region
-from modos.io import parse_instance
+from modos.io import parse_instance, parse_attributes
 from modos.prompt import SlotPrompter
 from modos.remote import EndpointManager
 from modos.prompt import SlotPrompter, fuzzy_complete
@@ -389,12 +389,12 @@ def update(
             help="File defining the updated modo. The file must be in json or yaml format.",
         ),
     ],
-    no_remove: Annotated[
+    force: Annotated[
         bool,
         typer.Option(
-            "--no-remove",
-            "-n",
-            help="Do not remove elements that are missing in the config_file.",
+            "--force",
+            "-f",
+            help="Force deletion of elements that are missing in the config_file.",
         ),
     ] = False,
 ):
@@ -402,12 +402,37 @@ def update(
 
     typer.echo(f"Updating {object_path}.", err=True)
     endpoint = ctx.obj.endpoint
-    _ = MODO.from_file(
-        config_path=config_file,
-        object_path=object_path,
-        endpoint=endpoint,
-        no_remove=no_remove,
-    )
+    if force:
+        _ = MODO.from_file(
+            config_path=config_file,
+            object_path=object_path,
+            endpoint=endpoint,
+            no_remove=False,
+        )
+    else:
+        element_list = parse_attributes(Path(config_file))
+        new_ids = [ele["element"].get("id") for ele in element_list]
+        _ = MODO.from_file(
+            config_path=config_file,
+            object_path=object_path,
+            endpoint=endpoint,
+            no_remove=True,
+        )
+        modo_id = _.zarr["/"].attrs["id"]
+        meta_ids = {Path(id).name: id for id in _.metadata.keys()}
+        old_ids = [
+            id for id in meta_ids.keys() if id not in new_ids and id != modo_id
+        ]
+        for old_id in old_ids:
+            delete = typer.confirm(
+                f"Could not find element '{old_id}' in config_file.\n Shall {old_id} be deleted?"
+            )
+            if not delete:
+                print(
+                    f"Keep {old_id} as part of {modo_id}. Consider updating your config_file."
+                )
+                continue
+            _.remove_element(meta_ids[old_id])
 
 
 def version_callback(value: bool):

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -425,7 +425,7 @@ def update(
         ]
         for old_id in old_ids:
             delete = typer.confirm(
-                f"Could not find element '{old_id}' in config_file.\n Shall {old_id} be deleted?"
+                f"Object contains element '{old_id}' which was not in config_file.\n Delete {old_id} ?"
             )
             if not delete:
                 print(

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -411,7 +411,7 @@ def update(
         )
     else:
         element_list = parse_attributes(Path(config_file))
-        new_ids = [ele["element"].get("id") for ele in element_list]
+        config_ids = [ele["element"].get("id") for ele in element_list]
         _ = MODO.from_file(
             config_path=config_file,
             object_path=object_path,
@@ -421,7 +421,9 @@ def update(
         modo_id = _.zarr["/"].attrs["id"]
         meta_ids = {Path(id).name: id for id in _.metadata.keys()}
         old_ids = [
-            id for id in meta_ids.keys() if id not in new_ids and id != modo_id
+            id
+            for id in meta_ids.keys()
+            if id not in config_ids and id != modo_id
         ]
         for old_id in old_ids:
             delete = typer.confirm(
@@ -429,7 +431,7 @@ def update(
             )
             if not delete:
                 print(
-                    f"Keeping {old_id} in of {modo_id}. Consider updating your config_file."
+                    f"Keeping {old_id} in {modo_id}. Consider updating your config_file."
                 )
                 continue
             _.remove_element(meta_ids[old_id])

--- a/modos/cli.py
+++ b/modos/cli.py
@@ -429,7 +429,7 @@ def update(
             )
             if not delete:
                 print(
-                    f"Keep {old_id} as part of {modo_id}. Consider updating your config_file."
+                    f"Keeping {old_id} in of {modo_id}. Consider updating your config_file."
                 )
                 continue
             _.remove_element(meta_ids[old_id])


### PR DESCRIPTION
### Aim: 
Add force flag to `modos update`. See https://github.com/sdsc-ordes/modos-api/issues/114

### Changes:
Replace `--no-remove` with `--force` flag in `modos update`. Instead of explicitly allowing to __not__ remove missing elements, this PR implements the following logic, if an existing element is missing from `config_file`:
 - prompt for explicit deletion by default 
 - add --force flag to skip prompts