### PR TITLE
ci(docker): fix version parsing  on release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get current release version
         id: release-version
         run: |
-          version=$(grep -E '^version += +' pyproject.toml | sed -E 's/.*= +//' | sed "s/['\"]//g")
+          version=$(grep -E '^__version__ += +' src/modos/__init__.py | sed -E 's/.*= +//' \ | tr -d '"')
           echo "version=${version}" >> $GITHUB_OUTPUT
 
       # https://github.com/docker/login-action

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,7 +53,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable=${{ github.event_name == 'push' || github.event_name == 'pull_request'}}
-            type=raw,value=${{ steps.release-version.outputs.version }},enable=${{ github.event_name == 'release' || github.event_name == 'push' || github.event_name == 'pull_request' }}
+            type=raw,value=${{ steps.release-version.outputs.version }},enable=${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
 
       # https://github.com/docker/build-push-action
       - name: Push Docker image

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,7 +53,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable=${{ github.event_name == 'push' || github.event_name == 'pull_request'}}
-            type=raw,value=${{ steps.release-version.outputs.version }},enable=${{ github.event_name == 'release' }}
+            type=raw,value=${{ steps.release-version.outputs.version }},enable=${{ github.event_name == 'release' || github.event_name == 'push' || github.event_name == 'pull_request' }}
 
       # https://github.com/docker/build-push-action
       - name: Push Docker image


### PR DESCRIPTION
* Fetch version from `__init__.py` instead of `pyproject.toml`
* Allow pushing docker images with version tags manually using workflow dispatch (in addition to on release)