### PR TITLE
fix(api): sequential encryption

### DIFF
--- a/src/modos/genomics/formats.py
+++ b/src/modos/genomics/formats.py
@@ -7,6 +7,8 @@ import pysam
 
 from modos.genomics.region import Region
 
+MAGIC_NUMBER = b"crypt4gh"
+
 
 class GenomicFileSuffix(tuple, Enum):
     """Enumeration of all supported genomic file suffixes."""
@@ -91,9 +93,23 @@ def get_index(file_path: Path) -> Optional[Path]:
         return None
 
 
-def toggle_c4gh_file_path(file_path: Path) -> Path:
-    """Toggle the c4gh encrypted file path to an unencrypted file path and vice versa."""
-    if file_path.suffix == ".c4gh":
-        return file_path.with_name(file_path.stem)
+def is_encrypted(file_path):
+    with open(file_path, "rb") as f:
+        magic = f.read(8)
+    return magic == MAGIC_NUMBER
+
+
+def add_suffix(file_path: Path, suffix: str) -> Path:
+    """Return the file path with specific suffix."""
+    if file_path.suffix == suffix:
+        return file_path
     else:
-        return file_path.with_suffix(file_path.suffix + ".c4gh")
+        return file_path.with_suffix(file_path.suffix + suffix)
+
+
+def remove_suffix(file_path: Path, suffix: str) -> Path:
+    """Return the file path without specific suffix."""
+    if file_path.suffix == suffix:
+        return file_path.with_suffix("")
+    else:
+        return file_path

--- a/src/modos/helpers/schema.py
+++ b/src/modos/helpers/schema.py
@@ -294,7 +294,10 @@ class DataElement:
         data_path = Path(self.model.data_path)
         if not is_encrypted(self.storage.path / data_path):
             return
-
+        if data_path.suffix != ".c4gh":
+            raise ValueError(
+                f"File {data_path} has unknown suffix.\n Please rename to .c4gh before decryption."
+            )
         decrypted_path = remove_suffix(data_path, ".c4gh")
         idx_path = get_index(decrypted_path)
         if idx_path:


### PR DESCRIPTION
## Changes

- check if files are encrypted through file header bytes.
- handles file suffixes unambigously (`add` or `remove` suffix instead of `toggle`).
- (decryption): raise error if c4gh encrypted, but no `c4gh`suffix. This should not happen. Modos and c4gh libs add `.c4gh` as suffix, but this is no strict requirement.

## Limitations
- only checks for crypt4gh encryption. I think that is reasonable as we only support c4gh encryption