### PR TITLE
ci(docker): fix release tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Get current release version
         id: release-version
         run: |
-          version=$(grep -E '^__version__ += +' src/modos/__init__.py | sed -E 's/.*= +//' \ | tr -d '"')
+          version=$(grep -E '^__version__ += +' src/modos/__init__.py | sed -E 's/.*= +//' | tr -d '"')
           echo "version=${version}" >> $GITHUB_OUTPUT
 
       # https://github.com/docker/login-action

--- a/tools/deploy/modos-server/Dockerfile
+++ b/tools/deploy/modos-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sdsc-ordes/modos-api:0.2.3
+FROM ghcr.io/sdsc-ordes/modos-api:0.3.1
 
 USER root
 


### PR DESCRIPTION
* Fixes tag extraction in docker publish CI workflow
* Bumps the tag of the base layer for the server image