### PR TITLE
docs: fix link to deploy from root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Provide a digital object and system to process, store and serve multi-omics data
 
 The client library by itself can be used to work with local MODOs, or connect to a server to access objects over s3.
 
-The server configuration and setup insructions can be found in [deploy](deploy). It consists of a REST API, an s3 server and an htsget server to stream CRAM/BCF over the network. The aim is to provide transparent remote access to MODOs without storing the data locally.
+The server configuration and setup insructions can be found in [deploy](tools/deploy/README.md). It consists of a REST API, an s3 server and an htsget server to stream CRAM/BCF over the network. The aim is to provide transparent remote access to MODOs without storing the data locally.
 
 ### Format
 


### PR DESCRIPTION
Fixes a broken link to the configuration and deploy instructions from the root README.