### PR TITLE
feat(fuzon): cli fallback without autocomplete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pandas>=2.2.3,<3.0.0",
     "prompt-toolkit>=3.0.48,<4.0.0",
     "pydantic>=2.8.2,<3.0.0",
+    "pyfuzon>=0.4,<0.5; sys_platform != 'win32'",
     "pysam>=0.22.0,<0.24.0",
     "pyteomics>=4.7.4,<5.0.0",
     "pyyaml>=6.0.1,<7.0.0",
@@ -27,9 +28,6 @@ dependencies = [
     "click>=8.1.3,<8.2.0",
     "zarr>=2.16.1,<3.0.0",
 ]
-
-[project.optional-dependencies]
-pyfuzon = ["pyfuzon>=0.4"]
 
 [dependency-groups]
 dev = [

--- a/src/modos/codes.py
+++ b/src/modos/codes.py
@@ -1,7 +1,7 @@
 """Utilities to automatically find / recommend terminology codes from text."""
 
 from dataclasses import dataclass
-from typing import override, Protocol
+from typing import Protocol
 
 from pathlib import Path
 import requests
@@ -55,7 +55,6 @@ class LocalCodeMatcher(CodeMatcher):
             cache.cache_by_source(sources)
             self.matcher = cache.load_by_source(sources)
 
-    @override
     def find_codes(self, query: str) -> list[Code]:
         return self.matcher.top(query, self.top)
 
@@ -68,7 +67,6 @@ class RemoteCodeMatcher(CodeMatcher):
         self.slot: str = slot
         self.top: int = top
 
-    @override
     def find_codes(self, query: str) -> list[Code]:
         codes: list[dict[str, str]] = requests.get(
             f"{self.endpoint}/codes/top?collection={self.slot}&query={query}&num={self.top}"

--- a/src/modos/prompt.py
+++ b/src/modos/prompt.py
@@ -1,10 +1,12 @@
+from collections.abc import Mapping
 from datetime import date
 import re
-from typing import Any, List, Mapping, Optional
+from typing import Any
 
 import click
 from prompt_toolkit import prompt
-from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.completion import CompleteEvent, Completer, Completion
+from prompt_toolkit.document import Document
 import typer
 
 from modos.codes import CodeMatcher, get_slot_matchers
@@ -22,11 +24,11 @@ class SlotCodeCompleter(Completer):
     """Auto-suggestions for terminology codes."""
 
     def __init__(self, matcher: CodeMatcher):
-        self.matcher = matcher
+        self.matcher: CodeMatcher = matcher
 
-    def get_completions(self, document, complete_event):
-        self.matcher.find_codes(document.text)
-
+    def get_completions(
+        self, document: Document, complete_event: CompleteEvent
+    ):
         for rec in self.matcher.find_codes(document.text):
             yield Completion(
                 f"{rec.label} {rec.uri}",
@@ -64,9 +66,9 @@ class SlotPrompter:
 
     def __init__(
         self,
-        endpoint: Optional[EndpointManager] = None,
-        suggest=True,
-        prompt: Optional[str] = None,
+        endpoint: EndpointManager | None = None,
+        suggest: bool = True,
+        prompt: str | None = None,
     ):
         self.prompt = prompt
         if suggest:
@@ -106,7 +108,9 @@ class SlotPrompter:
         return output
 
     def prompt_for_slots(
-        self, target_class: type, exclude: Optional[Mapping[str, List]] = None
+        self,
+        target_class: type,
+        exclude: Mapping[str, list[str]] | None = None,
     ) -> dict[str, Any]:
         """Prompt the user to provide values for the slots of input class.
         values of required fields can be excluded to repeat the prompt.

--- a/uv.lock
+++ b/uv.lock
@@ -1163,6 +1163,7 @@ dependencies = [
     { name = "pandas" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
+    { name = "pyfuzon", marker = "sys_platform != 'win32'" },
     { name = "pysam" },
     { name = "pyteomics" },
     { name = "pyyaml" },
@@ -1170,11 +1171,6 @@ dependencies = [
     { name = "s3fs" },
     { name = "typer" },
     { name = "zarr" },
-]
-
-[package.optional-dependencies]
-pyfuzon = [
-    { name = "pyfuzon" },
 ]
 
 [package.dev-dependencies]
@@ -1204,7 +1200,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2.3,<3.0.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.48,<4.0.0" },
     { name = "pydantic", specifier = ">=2.8.2,<3.0.0" },
-    { name = "pyfuzon", marker = "extra == 'pyfuzon'", specifier = ">=0.4" },
+    { name = "pyfuzon", marker = "sys_platform != 'win32'", specifier = ">=0.4,<0.5" },
     { name = "pysam", specifier = ">=0.22.0,<0.24.0" },
     { name = "pyteomics", specifier = ">=4.7.4,<5.0.0" },
     { name = "pyyaml", specifier = ">=6.0.1,<7.0.0" },
@@ -1213,7 +1209,6 @@ requires-dist = [
     { name = "typer", extras = ["rich"], specifier = ">=0.7.0,<1.0.0" },
     { name = "zarr", specifier = ">=2.16.1,<3.0.0" },
 ]
-provides-extras = ["pyfuzon"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This PR makes pyfuzon a core dependency on all platform except for windows.
When neither a fuzon server, nor a pyfuzon client are available (on windows), the CLI gracefully falls back to plain-text interface without auto-suggestions, instead of crashing.

