### PR TITLE
fix(api): auto-attach assays to MODO

### DIFF
--- a/src/modos/api.py
+++ b/src/modos/api.py
@@ -350,6 +350,10 @@ class MODO:
         type_group = self.zarr[type_name]
         element_path = f"{type_name}/{element.id}"
 
+        # Assays are always bound to the MODO itself.
+        if type_name == "assay":
+            part_of = "/"
+
         if part_of is not None:
             partof_group = self.zarr[part_of]
             set_haspart_relationship(


### PR DESCRIPTION
Assays are not auto-linked to the MODO when added through the CLI / API unless they are explicitely mentioning `--parent /`. This result in a missing link from MODO.has_assay`.

Since all assays are necessarily attached to the MODO, this PR proposes to auto-fill the parent for assays.