### PR TITLE
feat(cli): pass s3 credentials via env

### DIFF
--- a/docs/tutorials/modo_remote.md
+++ b/docs/tutorials/modo_remote.md
@@ -46,7 +46,7 @@ remo.get_s3_path("http://localhost", query="ex", exact_match=True)
 
 ## Instantiate a remote MODO locally
 
-Remotely stored `MODOs` can be instantiated by specifying their remote endpoint and then and worked with as if they were stored locally.
+Remotely stored `MODOs` can be instantiated by specifying their remote endpoint and then worked with as if they were stored locally.
 
 The example below assumes a public s3 bucket endpoint accessible anonymously (without credentials).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
   "pyinstrument",
   "pytest",
   "testcontainers[minio]",
+  "pytest-httpserver>=1.1.3",
 ]
 docs = [
   "myst-parser>=2.0.0,<3.0",

--- a/src/modos/cli/codes.py
+++ b/src/modos/cli/codes.py
@@ -40,7 +40,7 @@ def search(
 
     matcher = get_slot_matcher(
         slot,
-        EndpointManager(ctx.obj.endpoint).fuzon,
+        EndpointManager(ctx.obj["endpoint"]).fuzon,
     )
     matcher.top = top
     if query:

--- a/src/modos/cli/main.py
+++ b/src/modos/cli/main.py
@@ -10,7 +10,6 @@ from typing_extensions import Annotated
 from loguru import logger
 from pydantic import HttpUrl
 import typer
-from types import SimpleNamespace
 
 from modos import __version__
 from modos.cli.codes import codes
@@ -49,9 +48,18 @@ def version_callback(value: bool):
         raise typer.Exit()
 
 
+def anon_callback(ctx: typer.Context, anon: bool):
+    """Validates modos server url"""
+    ctx.ensure_object(dict)
+    ctx.obj.setdefault("s3_kwargs", {})["anon"] = anon
+    return anon
+
+
 def endpoint_callback(ctx: typer.Context, url: HttpUrl):
     """Validates modos server url"""
-    ctx.obj = SimpleNamespace(endpoint=url)
+    ctx.ensure_object(dict)
+    ctx.obj["endpoint"] = url
+    return url
 
 
 @cli.command(rich_help_panel="Read")
@@ -128,6 +136,13 @@ def callback(
         callback=endpoint_callback,
         envvar="MODOS_ENDPOINT",
         help="URL of modos server.",
+    ),
+    anon: Optional[bool] = typer.Option(
+        None,
+        "--anon",
+        callback=anon_callback,
+        envvar="MODOS_ANON",
+        help="Use anonymous access for S3 connections.",
     ),
     version: Optional[bool] = typer.Option(
         None,

--- a/src/modos/cli/main.py
+++ b/src/modos/cli/main.py
@@ -146,7 +146,7 @@ def callback(
         help="URL of modos server.",
     ),
     anon: Optional[bool] = typer.Option(
-        None,
+        False,
         "--anon",
         callback=anon_callback,
         envvar="MODOS_ANON",

--- a/src/modos/cli/main.py
+++ b/src/modos/cli/main.py
@@ -93,9 +93,13 @@ def show(
     """Show the contents of a modo."""
     from modos.api import MODO
 
-    endpoint = ctx.obj.endpoint
+    endpoint = ctx.obj["endpoint"]
     if endpoint:
-        obj = MODO(object_path, endpoint=endpoint)
+        obj = MODO(
+            object_path,
+            endpoint=endpoint,
+            s3_kwargs=ctx.obj["s3_kwargs"],
+        )
     elif os.path.exists(object_path):
         obj = MODO(object_path)
     else:
@@ -120,7 +124,11 @@ def publish(
     """Export a modo as linked data. Turns all paths into URIs."""
     from modos.api import MODO
 
-    obj = MODO(object_path, endpoint=ctx.obj.endpoint)
+    obj = MODO(
+        object_path,
+        endpoint=ctx.obj["endpoint"],
+        s3_kwargs=ctx.obj["s3_kwargs"],
+    )
     print(
         obj.knowledge_graph(uri_prefix=base_uri).serialize(
             format=output_format
@@ -198,11 +206,11 @@ def create(
 
     typer.echo("Creating a digital object.", err=True)
 
-    endpoint = EndpointManager(ctx.obj.endpoint)
+    endpoint = EndpointManager(ctx.obj["endpoint"])
 
     # Initialize object's directory
     if endpoint.s3:
-        fs = connect_s3(endpoint.s3, {"anon": True})  # type: ignore
+        fs = connect_s3(endpoint.s3, ctx.obj["s3_kwargs"])  # type: ignore
         if fs.exists(object_path):
             raise ValueError(f"Remote directory already exists: {object_path}")
     elif Path(object_path).exists():
@@ -224,7 +232,12 @@ def create(
 
     attrs = obj.__dict__
     # Dump object to zarr metadata
-    MODO(path=object_path, endpoint=endpoint.modos, **attrs)
+    MODO(
+        path=object_path,
+        endpoint=endpoint.modos,
+        s3_kwargs=ctx.obj["s3_kwargs"],
+        **attrs,
+    )
 
 
 @cli.command(rich_help_panel="Write")
@@ -251,7 +264,11 @@ def remove(
     from modos.api import MODO
     import zarr
 
-    modo = MODO(object_path, endpoint=ctx.obj.endpoint)
+    modo = MODO(
+        object_path,
+        endpoint=ctx.obj["endpoint"],
+        s3_kwargs=ctx.obj["s3_kwargs"],
+    )
     if (element_id is None) or (element_id == modo.path.name):
         if force:
             modo.remove_object()
@@ -323,9 +340,13 @@ def add(
     from modos.remote import EndpointManager
 
     typer.echo(f"Updating {object_path}.", err=True)
-    modo = MODO(object_path, endpoint=ctx.obj.endpoint)
+    modo = MODO(
+        object_path,
+        endpoint=ctx.obj["endpoint"],
+        s3_kwargs=ctx.obj["s3_kwargs"],
+    )
     target_class = element_type.get_target_class()
-    endpoint = EndpointManager(ctx.obj.endpoint)
+    endpoint = EndpointManager(ctx.obj["endpoint"])
 
     if from_file and element:
         raise ValueError("Only one of --from-file or --element can be used.")
@@ -351,7 +372,11 @@ def enrich(
     import zarr
 
     typer.echo(f"Enriching metadata for {object_path}.", err=True)
-    modo = MODO(object_path, endpoint=ctx.obj.endpoint)
+    modo = MODO(
+        object_path,
+        endpoint=ctx.obj["endpoint"],
+        s3_kwargs=ctx.obj["s3_kwargs"],
+    )
     # Attempt to extract metadata from files
     modo.enrich_metadata()
     zarr.consolidate_metadata(modo.zarr.store)
@@ -383,12 +408,12 @@ def update(
     from modos.io import parse_attributes
 
     typer.echo(f"Updating {object_path}.", err=True)
-    endpoint = ctx.obj.endpoint
     if force:
         _ = MODO.from_file(
             config_path=config_file,
             object_path=object_path,
-            endpoint=endpoint,
+            endpoint=ctx.obj["endpoint"],
+            s3_kwargs=ctx.obj["s3_kwargs"],
             no_remove=False,
         )
     else:
@@ -397,7 +422,8 @@ def update(
         _ = MODO.from_file(
             config_path=config_file,
             object_path=object_path,
-            endpoint=endpoint,
+            endpoint=ctx.obj["endpoint"],
+            s3_kwargs=ctx.obj["s3_kwargs"],
             no_remove=True,
         )
         modo_id = _.zarr["/"].attrs["id"]

--- a/src/modos/cli/remote.py
+++ b/src/modos/cli/remote.py
@@ -27,7 +27,11 @@ def download(
     """Download a modo from a remote endpoint."""
     from modos.api import MODO
 
-    modo = MODO(object_path, endpoint=ctx.obj.endpoint)
+    modo = MODO(
+        object_path,
+        endpoint=ctx.obj["endpoint"],
+        s3_kwargs=ctx.obj["s3_kwargs"],
+    )
     modo.download(target_path)
 
 
@@ -49,8 +53,8 @@ def upload(
     from modos.remote import EndpointManager
 
     modo = MODO(object_path)
-    endpoint = EndpointManager(ctx.obj.endpoint)
-    modo.upload(target_path, endpoint.s3)
+    endpoint = EndpointManager(ctx.obj["endpoint"])
+    modo.upload(target_path, endpoint.s3, s3_kwargs=ctx.obj["s3_kwargs"])
 
 
 @remote.command()
@@ -60,10 +64,10 @@ def list(
     """List remote modos on the endpoint."""
     from modos.remote import list_remote_items
 
-    if ctx.obj.endpoint is None:
+    if ctx.obj["endpoint"] is None:
         raise ValueError("Must provide an endpoint using modos --endpoint")
 
-    for item in list_remote_items(ctx.obj.endpoint):
+    for item in list_remote_items(ctx.obj["endpoint"]):
         print(item)
 
 
@@ -95,7 +99,7 @@ def stream(
 
     # NOTE: bucket is not included in htsget paths
     source = Path(*Path(file_path.removeprefix("s3://")).parts[1:])
-    endpoint = EndpointManager(ctx.obj.endpoint)
+    endpoint = EndpointManager(ctx.obj["endpoint"])
 
     if not endpoint:
         raise ValueError("Streaming requires a remote endpoint.")

--- a/src/modos/storage.py
+++ b/src/modos/storage.py
@@ -193,9 +193,21 @@ class S3Storage(Storage):
         s3_endpoint: HttpUrl,
         s3_kwargs: Optional[dict[str, Any]] = None,
     ):
+        """S3 storage based on s3fs.
+
+        Parameters
+        ----------
+        path:
+            S3 path to the object (format: s3://bucket/name).
+        s3_endpoint:
+            URL to the S3 endpoint.
+        s3_kwargs:
+            Additional keyword arguments passed to s3fs.S3FileSystem.
+            To use public access buckets without authentification, pass {"anon": True}.
+        """
         self._path = S3Path(url=path)
         self.endpoint = s3_endpoint
-        s3_opts = s3_kwargs or {"anon": True}
+        s3_opts = s3_kwargs or {}
         fs = connect_s3(s3_endpoint, s3_opts)
         if fs.exists(str(self.path / ZARR_ROOT)):
             zarr_s3_opts = s3_opts | {"endpoint_url": str(s3_endpoint)}

--- a/tests/test_cli_remote.py
+++ b/tests/test_cli_remote.py
@@ -1,0 +1,46 @@
+"""Tests for the remote use of multi-omics digital object (modo) CLI"""
+
+from typer.testing import CliRunner
+
+from modos.cli import cli
+import pytest
+
+runner = CliRunner()
+
+
+@pytest.mark.slow
+def test_create_modo_auth(setup):
+    minio_endpoint = setup["minio"].get_config()["endpoint"]
+    result = runner.invoke(
+        cli,
+        [
+            "create",
+            "-m",
+            '{"id":"test", "creation_date": "2024-05-14", "last_update_date": "2024-05-14"}',
+            "s3://test/ex",
+        ],
+        env={
+            "AWS_ACCESS_KEY_ID": "minioadmin",
+            "AWS_SECRET": "minioadmin",
+            "MODOS_ENDPOINT": f"http://{minio_endpoint}",
+        },
+    )
+    assert result.exit_code == 0
+
+
+@pytest.mark.slow
+def test_show_modo_anon(setup):
+    endpoint = setup["minio"].get_config()["endpoint"]
+    result = runner.invoke(
+        cli,
+        [
+            "--endpoint",
+            f"http://{endpoint}",
+            "--anon",
+            "create",
+            "-m",
+            '{"id":"test", "creation_date": "2024-05-14", "last_update_date": "2024-05-14"}',
+            "s3://test/ex",
+        ],
+    )
+    assert result.exit_code == 0

--- a/tests/test_cli_remote.py
+++ b/tests/test_cli_remote.py
@@ -4,13 +4,17 @@ from typer.testing import CliRunner
 
 from modos.cli import cli
 import pytest
+from pytest_httpserver import HTTPServer
 
 runner = CliRunner()
 
 
 @pytest.mark.slow
-def test_create_modo_auth(setup):
+def test_create_modo_auth(setup, httpserver: HTTPServer):
     minio_endpoint = setup["minio"].get_config()["endpoint"]
+    httpserver.expect_request("/").respond_with_json(
+        {"status": "success", "s3": f"http://{minio_endpoint}"}
+    )
     result = runner.invoke(
         cli,
         [
@@ -21,26 +25,26 @@ def test_create_modo_auth(setup):
         ],
         env={
             "AWS_ACCESS_KEY_ID": "minioadmin",
-            "AWS_SECRET": "minioadmin",
-            "MODOS_ENDPOINT": f"http://{minio_endpoint}",
+            "AWS_SECRET_ACCESS_KEY": "minioadmin",
+            "MODOS_ENDPOINT": httpserver.url_for("/"),
         },
     )
     assert result.exit_code == 0
 
 
 @pytest.mark.slow
-def test_show_modo_anon(setup):
-    endpoint = setup["minio"].get_config()["endpoint"]
+def test_list_modo(httpserver: HTTPServer):
+    httpserver.expect_request("/list").respond_with_json(
+        {"modos": ["s3://test/ex"]}
+    )
     result = runner.invoke(
         cli,
         [
             "--endpoint",
-            f"http://{endpoint}",
+            httpserver.url_for("/"),
             "--anon",
-            "create",
-            "-m",
-            '{"id":"test", "creation_date": "2024-05-14", "last_update_date": "2024-05-14"}',
-            "s3://test/ex",
+            "remote",
+            "list",
         ],
     )
     assert result.exit_code == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1178,6 +1178,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pyinstrument" },
     { name = "pytest" },
+    { name = "pytest-httpserver" },
     { name = "ruff" },
     { name = "testcontainers", extra = ["minio"] },
 ]
@@ -1216,6 +1217,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pyinstrument" },
     { name = "pytest" },
+    { name = "pytest-httpserver", specifier = ">=1.1.3" },
     { name = "ruff" },
     { name = "testcontainers", extras = ["minio"] },
 ]
@@ -1927,6 +1929,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-httpserver"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/d8/def15ba33bd696dd72dd4562a5287c0cba4d18a591eeb82e0b08ab385afc/pytest_httpserver-1.1.3.tar.gz", hash = "sha256:af819d6b533f84b4680b9416a5b3f67f1df3701f1da54924afd4d6e4ba5917ec", size = 68870, upload-time = "2025-04-10T08:17:15.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/d2/dfc2f25f3905921c2743c300a48d9494d29032f1389fc142e718d6978fb2/pytest_httpserver-1.1.3-py3-none-any.whl", hash = "sha256:5f84757810233e19e2bb5287f3826a71c97a3740abe3a363af9155c0f82fdbb9", size = 21000, upload-time = "2025-04-10T08:17:13.906Z" },
+]
+
+[[package]]
 name = "pytest-logging"
 version = "2015.11.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2498,6 +2512,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds support for s3 credentials through the command line interface via environment variables.

## Changes

The default behavious in modos until now was to pass `{"anon": True}` to the s3fs client.
This PR chnages the default to False so that it automatically scans standard AWS S3 environment variables.

Anonymous access is still possible through a new `--anon` toplevel flag on the CLI.