### PR TITLE
fix: vcf streaming with pysam

### DIFF
--- a/src/modos/genomics/formats.py
+++ b/src/modos/genomics/formats.py
@@ -76,7 +76,14 @@ def read_pysam(
         case _:
             raise ValueError("Unsupported output file type.")
 
-    pysam_handle = pysam_func(str(path), **kwargs)
+    try:
+        pysam_handle = pysam_func(str(path), **kwargs)
+    except TypeError as e:
+        if "unexpected keyword argument" in str(e):
+            pysam_handle = pysam_func(str(path))
+        else:
+            raise
+
     if region is None:
         stream = (rec for rec in pysam_handle)
     else:

--- a/src/modos/genomics/htsget.py
+++ b/src/modos/genomics/htsget.py
@@ -267,7 +267,7 @@ class HtsgetConnection:
         # TODO: when above addressed, replace temporary file with
         # self.open() to stream directly from in-memory buffer.
         buffer = tempfile.NamedTemporaryFile(
-            "w+b", delete=False, suffix=self.path.suffix
+            "w+b", delete=False, suffix="".join(self.path.suffixes)
         ).name
 
         self.to_file(Path(buffer))


### PR DESCRIPTION
## VCF file streaming in python:

"Streaming" in python did not work for vcf files because:
- `to_pysam` did not extract the full suffix for gzipped files (e.g. `.vcf.gz` --> only `.gz`).  Thus tmp-files received the wrong suffix and failed.
- pysam raised a TypeError in the `VariantFile` call because we parsed `reference_filename` as part of **kwargs. `reference_filename` is only a valid parameter of `AlignmentFile`.

## Example:
```python

from modos.api import MODO
url = "https://modos.dscompute.ch"
modo = MODO(path = "s3://modos-demo/AIP", endpoint = url)

test=modo.stream_genomics(file_path = 'modos-demo/AIP/AIP.vcf.gz', region = "chromosome7:798425")
for rec in test:
  print(rec)
``