### PR TITLE
fix(deploy-s3): use env variables to specify bucket names

### DIFF
--- a/tools/deploy/compose.yaml
+++ b/tools/deploy/compose.yaml
@@ -9,7 +9,6 @@ networks:
     driver: bridge
 
 services:
-
   caddy:
     image: docker.io/caddy:2
     restart: always
@@ -34,7 +33,6 @@ services:
     networks:
       - modos-network
 
-
   garage:
     build: ./garage
     restart: unless-stopped
@@ -53,9 +51,10 @@ services:
     environment:
       - GARAGE_ADMIN_TOKEN=${GARAGE_ADMIN_TOKEN:-garage}
       - GARAGE_S3_REGION=${GARAGE_S3_REGION:-us-east-1}
+      - S3_BUCKET=${S3_BUCKET:-modos-demo}
+      - REFERENCE_BUCKET=${REFERENCE_BUCKET:-reference-genomes}
       - CLIENT_ID=${AWS_ACCESS_KEY_ID:-garage}
       - CLIENT_SECRET=${AWS_SECRET_ACCESS_KEY:-garage-secret}
-
 
   htsget:
     build: ./htsget
@@ -77,7 +76,6 @@ services:
       - AWS_REGION=${GARAGE_S3_REGION:-us-east-1}
       - RUST_LOG=debug
 
-
   fuzon:
     build: ./fuzon
     volumes:
@@ -86,7 +84,6 @@ services:
       - "9090"
     networks:
       - modos-network
-
 
   refget:
     build: ./refget
@@ -101,7 +98,6 @@ services:
       - BUCKET=${REFERENCE_BUCKET:-reference-genomes}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-garage}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-garage-secret}
-
 
   modos-server:
     build: ./modos-server

--- a/tools/deploy/garage/post-hook.sh
+++ b/tools/deploy/garage/post-hook.sh
@@ -3,6 +3,8 @@
 sleep 5
 garage layout assign -z dc1 -c 1G $(garage status | tail -n1 | cut -f1 -d' ' )
 garage layout apply --version 1
-garage bucket create modos-demo
+garage bucket create ${S3_BUCKET}
+garage bucket create ${REFERENCE_BUCKET}
 garage key import --yes ${CLIENT_ID} ${CLIENT_SECRET} -n demo
-garage bucket allow --read --write --owner modos-demo --key ${CLIENT_ID}
+garage bucket allow --read --write --owner ${S3_BUCKET} --key ${CLIENT_ID}
+garage bucket allow --read --write --owner ${REFERENCE_BUCKET} --key ${CLIENT_ID}


### PR DESCRIPTION
### Changes

- Use env variables to specify the name of the buckets generated when deploying the garage container
- Generate  the "S3 bucket" (bucket that contains the modos) AND the reference bucket