### PR TITLE
fix(deploy): use build arg to allow change of server base image

### DIFF
--- a/tools/deploy/modos-server/Dockerfile
+++ b/tools/deploy/modos-server/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/sdsc-ordes/modos-api:0.3.5
+ARG MODOS_API_IMAGE=ghcr.io/sdsc-ordes/modos-api:0.3.5
+FROM ${MODOS_API_IMAGE}
 
 USER modos_user
 WORKDIR /app
@@ -6,8 +7,8 @@ COPY ./server.py /app
 
 RUN uv venv -p 3.12 --allow-existing
 RUN uv pip install \
-  "fastapi ~= 0.109.2" \
-  "uvicorn ~= 0.27.0.post1"
+    "fastapi ~= 0.109.2" \
+    "uvicorn ~= 0.27.0.post1"
 
 ENTRYPOINT ["uv", "run", "--offline"]
 CMD ["uvicorn", "--reload", "server:app"]


### PR DESCRIPTION
## Summary

This should allow to build the server image with a different base image, e.g.:
```
docker build --build-arg MODOS_API_IMAGE=ghcr.io/sdsc-ordes/modos-api:latest
```

This should allow using the `latest` in dev deployments.