### PR TITLE
feat(auth): request jwt scopes

### DIFF
--- a/src/modos/remote.py
+++ b/src/modos/remote.py
@@ -10,7 +10,6 @@ from typing import Any
 import warnings
 
 import jwt
-from jwt.exceptions import ExpiredSignatureError
 from pydantic import HttpUrl, validate_call
 from pydantic.dataclasses import dataclass
 import requests
@@ -221,16 +220,3 @@ class JWT:
     def refresh(self) -> JWT | None:
         warnings.warn("Token refresh is not yet implemented.")
         return None
-
-    def decode(
-        self, client_secret: str, audience: str
-    ) -> dict[str, Any] | None:
-        try:
-            jwt.decode(
-                self.access_token,
-                client_secret,
-                algorithms="HS256",
-                audience=audience,
-            )
-        except ExpiredSignatureError:
-            self.refresh()


### PR DESCRIPTION
 ## Summary

Scopes need to be specifically requested during device code flow to be part of the JWT. This PR adds the following scopes:
- profile: user name, groups, etc.
- offline_use: required to receive a refresh token (not relevant for now, but will be in future)
- permissions: custom scope to specify read/write access

I hard-coded scopes here, because I'm hesitant to add more arguments to the cli command. But hard-coding is also sub-optimal, because the login will be declined in the browser (! no error we can fetch in a try, except), if the scopes do not match the scopes defined in authentik.

@cmdoret any alternative or opinion on this?