### PR TITLE
fix(cli): check remote path in modos show

### DIFF
--- a/src/modos/cli/main.py
+++ b/src/modos/cli/main.py
@@ -16,6 +16,7 @@ from modos.cli.c4gh import c4gh
 from modos.cli.common import OBJECT_PATH_ARG, RdfFormat
 from modos.cli.remote import remote
 from modos.helpers.enums import UserElementType
+from modos.remote import list_remote_items
 
 
 cli = typer.Typer(add_completion=False)
@@ -117,7 +118,7 @@ def show(
     from modos.api import MODO
 
     endpoint = ctx.obj["endpoint"]
-    if endpoint:
+    if endpoint and object_path in list_remote_items(endpoint):
         obj = MODO(
             object_path,
             endpoint=endpoint,


### PR DESCRIPTION
## Summary
Check, if a remote modos exists before initializing it in `modos --endpoint .. show`. 
The path was checked for local modos, but not for remote, which caused an empty modos to be created, if the `object_path` did not exist. 

The fix does a call to modos server, instead of directly checking the `object_path` using `obstore`, `boto3`  or alike libraries. 
This keeps code minimal and we cache the session for the server request, but directly checking the `object_path` still might be more stable/reliable? 



