### PR TITLE
fix(c4gh): update zarr consolidated metadata after {en,de}cryption

### DIFF
--- a/src/modos/api.py
+++ b/src/modos/api.py
@@ -613,6 +613,7 @@ class MODO:
             )
             update_metadata_from_model(group, data.model)
         self.update_date()
+        zarr.consolidate_metadata(self.zarr.store)
 
     def decrypt(
         self,
@@ -628,6 +629,7 @@ class MODO:
             data.decrypt(seckey_path, sender_pubkey, passphrase)
             update_metadata_from_model(group, data.model)
         self.update_date()
+        zarr.consolidate_metadata(self.zarr.store)
 
     def checksum(self) -> str:
         """Compute a single checksum for the MODO based on its contents.

--- a/tests/test_cli_local.py
+++ b/tests/test_cli_local.py
@@ -138,6 +138,7 @@ def test_encrypt_modo(test_modo, c4gh_keypair, tmp_path):
     assert result.exit_code == 0
     assert (tmp_path / "demo1.cram.c4gh").exists()
     assert not (tmp_path / "demo1.cram").exists()
+    assert test_modo.metadata["data/demo1"]["data_path"] == "demo1.cram.c4gh"
 
 
 ## Decryption


### PR DESCRIPTION
fixes #207 

Changes:
* explicitely consolidate zarr metadata upon c4gh operations